### PR TITLE
修复顺丰速运脚本推送通知AttributeError异常

### DIFF
--- a/script/sf/main.py
+++ b/script/sf/main.py
@@ -60,6 +60,7 @@ class SFTasksManager:
             config_path = Path(config_path)
 
         self.config_path = config_path
+        self.site_name = "顺丰速运"
         self.accounts = []
         self.task_summary = []
         self.load_config()
@@ -470,4 +471,3 @@ def main():
 if __name__ == '__main__':
     exit_code = main()
     sys.exit(exit_code)
-


### PR DESCRIPTION
## 问题描述

修复顺丰速运脚本在发送任务汇总推送通知时出现的 `AttributeError` 异常。

关联 Issue: #1

## 错误日志

```
2025-12-03 08:47:24,865 - __main__ - ERROR - ❌ 发送任务汇总推送失败: 'SFTasksManager' object has no attribute 'site_name'
Traceback (most recent call last):
  File "/ql/data/scripts/Cat-zaizai_ZaiZaiCat-Checkin/script/sf/main.py", line 342, in send_notification
    title = f"{self.site_name}积分任务完成 ✅"
               ^^^^^^^^^^^^^^
AttributeError: 'SFTasksManager' object has no attribute 'site_name'
```

## 问题原因

`SFTasksManager` 类在 `__init__` 方法中从未定义 `site_name` 属性，但在 `send_notification` 方法（第 343 行和第 393 行）中使用了 `self.site_name` 来构建推送标题和日志信息。

## 修改内容

在 `script/sf/main.py` 的 `SFTasksManager.__init__` 方法中添加：

```python
self.site_name = "顺丰速运"
```

**修改位置**：第 63 行，在 `self.config_path` 赋值之后

## 测试结果

修复后测试输出正常：

```
2025-12-03 09:44:18,516 - __main__ - INFO - ✅ 顺丰速运任务汇总推送发送成功
2025-12-03 09:44:18,516 - NotificationManager - INFO - ✅ Bark推送发送成功
```

## 影响范围

- ✅ 修复推送通知功能
- ✅ 不影响任务执行逻辑
- ✅ 向后兼容

## Checklist

- [x] 代码已在本地测试通过
- [x] 修复了 AttributeError 异常
- [x] 推送通知功能正常工作
- [x] 符合项目编码规范（UTF-8、PEP8）
- [x] 提交信息符合项目风格