### PR TITLE
修复看雪论坛签到脚本推送通知AttributeError异常

### DIFF
--- a/script/kanxue/sign_in.py
+++ b/script/kanxue/sign_in.py
@@ -50,6 +50,7 @@ class KanxueSignInManager:
             config_path = Path(config_path)
 
         self.config_path = config_path
+        self.site_name = "看雪论坛"
         self.accounts = []
         self.load_config()
 
@@ -331,4 +332,3 @@ def main():
 if __name__ == '__main__':
     exit_code = main()
     sys.exit(exit_code)
-


### PR DESCRIPTION
## 问题描述

修复看雪论坛签到脚本在发送推送通知时出现的 `AttributeError` 异常。

关联 Issue: #3

## 错误日志

```
2025-12-03 10:34:42,865 - __main__ - ERROR - 签到任务执行异常: 'KanxueSignInManager' object has no attribute 'site_name'
Traceback (most recent call last):
  File "/ql/data/scripts/Cat-zaizai_ZaiZaiCat-Checkin/script/kanxue/sign_in.py", line 176, in send_notification
    title = f"{self.site_name}签到成功 ✅"
               ^^^^^^^^^^^^^^
AttributeError: 'KanxueSignInManager' object has no attribute 'site_name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/ql/data/scripts/Cat-zaizai_ZaiZaiCat-Checkin/script/kanxue/sign_in.py", line 282, in main
    manager.send_notification(results, start_time, end_time)
  File "/ql/data/scripts/Cat-zaizai_ZaiZaiCat-Checkin/script/kanxue/sign_in.py", line 242, in send_notification
    logger.error(f"❌ {self.site_name}推送通知失败: {str(e)}", exc_info=True)
                       ^^^^^^^^^^^^^^
AttributeError: 'KanxueSignInManager' object has no attribute 'site_name'
```

## 问题原因

`KanxueSignInManager` 类在 `__init__` 方法中从未定义 `site_name` 属性，但在 `send_notification` 方法中多处使用了 `self.site_name`：
- 第 177 行：构建推送标题（成功情况）
- 第 180 行：构建推送标题（失败情况）
- 第 183 行：构建推送标题（部分成功情况）
- 第 240 行：记录成功日志
- 第 243 行：记录错误日志

这导致在异常处理时会再次抛出 `AttributeError`，使得用户无法收到任何通知。

## 修改内容

在 `script/kanxue/sign_in.py` 的 `KanxueSignInManager.__init__` 方法中添加：

```python
self.site_name = "看雪论坛"
```

**修改位置**：第 53 行，在 `self.config_path` 赋值之后

## 影响范围

- ✅ 修复推送通知功能
- ✅ 修复异常处理中的二次异常
- ✅ 不影响签到执行逻辑
- ✅ 向后兼容

## 相关问题

该问题与 #1 (顺丰速运脚本) 类似，属于同类型的属性缺失问题。

## Checklist

- [x] 代码已在本地测试通过
- [x] 修复了 AttributeError 异常
- [x] 修复了异常处理中的二次异常
- [x] 推送通知功能正常工作
- [x] 符合项目编码规范（UTF-8、PEP8）
- [x] 提交信息符合项目风格