### PR TITLE
✨ 新增 WorkBuddy(CodeBuddy) 自动签到模块

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | 👟 鸿星尔克      | `script/erke/main.py` | ✅ 可用 | 支持签到和积分明细查询         |
 | 📝 WPS Office  | `script/wps/main.py` | ✅ 可用 | 支持任务中心和天天领福利双页面任务 |
 | 💰 什么值得买      | `script/smzdm/sign_daily_task/main.py` | ✅ 可用 | 支持每日签到和众测任务         |
+| 🤖 WorkBuddy    | `script/workbuddy/main.py` | ✅ 可用 | 支持每日签到、令牌自动续期与多账号管理 |
 
 ### 状态说明
 
@@ -51,7 +52,25 @@ WPS 脚本目前包含两个活动页面：
 - `script/wps/daily_benefits.py`：天天领福利，支持打卡免费领会员、会员免费试用、天天抽奖
 - `script/wps/main.py`：WPS 统一入口，按账号顺序依次执行上述两个页面任务
 
+## 📝 WorkBuddy 功能说明
+
+WorkBuddy（CodeBuddy）每日签到脚本，接口实现参考 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 项目，与官方客户端行为保持一致：
+
+- `script/workbuddy/api.py`：接口封装，签到状态查询（双端点回退）、每日签到、令牌刷新
+- `script/workbuddy/import_accounts.py`：账号导入工具，支持从本机 cockpit-tools 数据目录自动导入（含加密账号自动解密），也支持指定 JSON 文件导入
+- `script/workbuddy/main.py`：统一入口，多账号签到编排、令牌自动续期与结果推送
+
+支持每日签到、连签奖励、多账号管理、令牌自动续期（access_token 60 天 / refresh_token 90 天，自动轮换续期），安装 cockpit-tools 的用户可在签到前自动同步最新令牌。详见 [script/workbuddy/README.md](script/workbuddy/README.md)。
+
 ## 📝 更新日志
+
+### 2026-09-06
+- ✨ **新增 WorkBuddy(CodeBuddy) 自动签到模块**:
+  - 📅 支持每日自动签到与连签奖励
+  - 🔄 支持令牌过期自动刷新并回写配置
+  - 📥 支持从本机 cockpit-tools 一键导入账号（含加密存储自动解密）
+  - ⏱️ 内置启动随机延迟与账号间随机间隔，自动错峰
+  - 📊 签到结果通过统一推送模块通知
 
 ### 2026-03-11
 - ✨ **WPS脚本升级为多页面任务**:

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -179,5 +179,18 @@
         "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
       }
     ]
+  },
+  "workbuddy": {
+    "accounts": [
+      {
+        "account_name": "主号",
+        "email": "you@example.com",
+        "access_token": "你的访问令牌",
+        "refresh_token": "你的刷新令牌",
+        "uid": "你的用户ID",
+        "enterprise_id": "",
+        "domain": "www.codebuddy.cn"
+      }
+    ]
   }
 }

--- a/script/workbuddy/README.md
+++ b/script/workbuddy/README.md
@@ -1,0 +1,201 @@
+# WorkBuddy 自动签到脚本
+
+WorkBuddy（腾讯 CodeBuddy）每日签到脚本，支持多账号、令牌自动续期、账号批量导入。
+
+签到接口实现参考 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 项目中 WorkBuddy 自动签到模块的实现，与官方客户端行为保持一致。
+
+## ✨ 功能特性
+
+- 🔐 **多账号支持** - 依次处理配置中的所有账号，账号间随机延迟 5-10 秒
+- 📥 **账号导入** - 从 cockpit-tools 批量导入账号，无需手动抄写令牌
+- 🔄 **自动同步** - 每次签到前自动从本机 cockpit-tools 拉取最新令牌（未安装则跳过）
+- 🔁 **令牌自动续期** - `access_token` 过期时用 `refresh_token` 自动换新并写回配置
+- 🎯 **智能判重** - 先查签到状态，今日已签到则跳过，不重复请求
+- ⏱️ **随机错峰** - 启动后在时间窗口内随机延迟，避开请求高峰
+- 📊 **结果推送** - 复用项目统一推送模块，输出积分与连签天数
+
+## 📁 文件说明
+
+| 文件 | 说明 |
+|------|------|
+| `main.py` | 主入口，多账号签到编排与结果推送 |
+| `api.py` | 接口封装：签到状态查询、每日签到、令牌刷新 |
+| `import_accounts.py` | 账号导入工具 |
+
+## 📦 安装依赖
+
+```bash
+pip install requests
+```
+
+## ⚙️ 配置说明
+
+账号配置写在项目根目录的 `config/token.json` 的 `workbuddy` 节点下：
+
+```json
+{
+  "workbuddy": {
+    "accounts": [
+      {
+        "account_name": "主号",
+        "email": "you@example.com",
+        "access_token": "你的访问令牌",
+        "refresh_token": "你的刷新令牌",
+        "uid": "你的用户ID",
+        "enterprise_id": "",
+        "domain": ""
+      }
+    ]
+  }
+}
+```
+
+### 字段说明
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `account_name` | 否 | 账号备注名，用于日志和推送显示 |
+| `email` | 否 | 账号邮箱，用于导入时去重 |
+| `access_token` | **是** | 访问令牌，对应请求头 `Authorization: Bearer` |
+| `refresh_token` | 否 | 刷新令牌，缺失时令牌过期只能手动重新导入 |
+| `uid` | 否 | 用户 ID，对应请求头 `X-User-Id` |
+| `enterprise_id` | 否 | 企业 ID，个人账号留空 |
+| `domain` | 否 | 域名，一般留空 |
+
+> **强烈建议填写 `refresh_token`**，否则令牌过期后签到会一直失败，需要人工介入。
+
+## 📥 导入账号
+
+### 方式一：从 cockpit-tools 自动导入（推荐）
+
+如果本机装了 cockpit-tools 并已登录 WorkBuddy 账号，直接运行：
+
+```bash
+python import_accounts.py
+```
+
+脚本会自动探测 cockpit-tools 的数据目录（含 `C:/Users/用户名/.antigravity_cockpit`），读取其中的账号并写入 `config/token.json`。
+
+> **加密账号自动解密**：cockpit-tools 新版将账号以 AES-256-GCM 加密存储，密钥在本机 `secure-account-storage.key`。导入工具会自动找到该密钥并解密，无需任何额外操作。明文与加密两种格式均已兼容。
+
+先预览不写入：
+
+```bash
+python import_accounts.py --list
+```
+
+### 方式二：指定路径导入
+
+自动探测失败时（例如 cockpit-tools 装在非默认位置），手动指定目录：
+
+```bash
+python import_accounts.py --path "C:/Users/你的用户名/AppData/Roaming/cockpit-tools"
+```
+
+也支持直接指定单个账号 JSON 文件，或包含账号数组的 JSON 文件：
+
+```bash
+python import_accounts.py --path "D:/backup/my_accounts.json"
+```
+
+### 导入行为说明
+
+- 按 `uid`（无则用 `email`）去重，**重复导入不会产生重复账号**
+- 已存在的账号只更新令牌等认证信息，**保留你自定义的 `account_name`**
+- cockpit-tools 的索引文件 `workbuddy_accounts.json` 只有摘要没有令牌，会自动跳过
+
+### 方式三：手动填写
+
+抓包获取令牌后，按上文配置格式手动填入 `config/token.json`。
+
+## 🔄 令牌有效期与自动续期
+
+根据实际令牌解析（JWT），CodeBuddy 签发规则如下：
+
+| 令牌 | 有效期 | 轮换方式 |
+|------|--------|---------|
+| `access_token` | 60 天 | 过期后用 `refresh_token` 换新 |
+| `refresh_token` | 90 天 | 刷新时随 `access_token` 一起换新，从刷新时刻重新计 90 天 |
+
+脚本在签到遇到令牌过期时会自动刷新并回写配置。**只要脚本每 90 天内至少成功运行一次，令牌即可无限续期**；连续 90 天未运行才需要重新导入账号。
+
+### 与 cockpit-tools 并行使用
+
+[cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的自动签到会在执行时刷新令牌（refresh token 轮换），这会使 `config/token.json` 里的旧令牌立即失效。脚本已内置应对：**每次签到前自动从本机 cockpit-tools 数据目录同步最新令牌**（未安装 cockpit-tools 时自动跳过，不影响独立使用）。若两边的自动签到都已开启，建议二选一，避免重复签到。
+
+## 🚀 使用方法
+
+```bash
+python main.py
+```
+
+执行流程：
+
+```
+从本机 cockpit-tools 同步最新令牌（未安装则跳过）
+  ↓
+随机延迟 0~10 分钟（错峰，可用 WORKBUDDY_JITTER_MAX 环境变量调整）
+  ↓
+加载账号配置
+  ↓
+循环处理每个账号
+  ├─ 查询签到状态
+  ├─ 今日已签到 → 跳过
+  ├─ 活动未开启 → 跳过
+  ├─ 未签到 → 执行签到
+  └─ 令牌过期 → 自动刷新后重试，并将新令牌写回配置
+  ↓
+输出统计信息并推送通知
+```
+
+## ⏰ 配置定时任务
+
+### Windows 任务计划程序
+
+1. 打开「任务计划程序」→ 创建基本任务
+2. 触发器：每天，建议设在 `07:00`~`09:00` 之间
+3. 操作：启动程序
+   - 程序：`python` 的完整路径，例如 `D:\python312\python.exe`
+   - 参数：`main.py`
+   - 起始于：`D:\test\qiandao\script\workbuddy`
+
+> **起始于必须填写**，否则脚本找不到项目根目录下的配置文件。
+
+命令行一键创建（管理员 PowerShell，路径按实际情况替换）：
+
+```powershell
+schtasks /create /tn "WorkBuddy签到" /tr "D:\test\qiandao\script\workbuddy\run.bat" /sc daily /st 08:30 /f
+```
+
+> 已通过 `run.bat` 启动器执行，内部使用 `pythonw.exe` 静默运行（不弹黑窗口），并自动切换到脚本目录，无需手动设置「起始于」。如需在锁屏/未登录时也执行，可在任务计划程序中把「安全选项」改为「不管用户是否登录都要运行」并保存密码。
+
+### 青龙面板
+
+脚本头部已包含青龙任务声明，默认每天 `08:30` 执行：
+
+```
+cron: 30 8 * * *
+```
+
+## 🔌 接口说明
+
+| 用途 | 方法与路径 |
+|------|-----------|
+| 签到状态 | `POST https://www.codebuddy.cn/v2/billing/meter/checkin-activity-status` |
+| 状态回退 | `POST https://www.codebuddy.cn/v2/billing/meter/checkin-status` |
+| 每日签到 | `POST https://www.codebuddy.cn/v2/billing/meter/daily-checkin` |
+| 刷新令牌 | `POST https://www.codebuddy.cn/v2/plugin/auth/token/refresh` |
+
+响应约定：仅 `code == 0` 视为成功，业务数据在 `data` 字段中，字段名兼容下划线与驼峰两种写法。
+
+## ⚠️ 注意事项
+
+1. **令牌安全** - `access_token` 等同于账号密码，切勿泄露或提交到公开仓库
+2. **签到时间** - 脚本已内置启动随机延迟避开整点，账号间另有 5-10 秒随机间隔，无需额外配置
+3. **令牌过期** - 若日志提示「令牌已过期，请重新导入账号」，重新运行 `import_accounts.py` 即可
+4. **多账号** - 账号间已内置 5-10 秒随机间隔，无需额外配置
+5. **个别账号被服务端拒绝** - 少数账号（如令牌类型为 `Offline`/`console` 的特殊账号）即便令牌未过期，也会被签到接口网关直接返回 401。这属于账号侧凭据问题，脚本无法绕过；可在 cockpit-tools 中重新登录该账号后重新导入，或将其从配置中移除。
+
+---
+
+**免责声明**: 本脚本仅供学习交流使用，使用产生的一切后果由使用者自行承担。

--- a/script/workbuddy/api.py
+++ b/script/workbuddy/api.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WorkBuddy API模块
+
+提供WorkBuddy(CodeBuddy CN)签到相关的API接口
+
+接口实现参考 cockpit-tools 项目 (https://github.com/jlcodes99/cockpit-tools)
+的 codebuddy_cn_oauth 模块，与官方客户端行为保持一致：
+- 签到状态: POST /v2/billing/meter/checkin-activity-status (失败回退 checkin-status)
+- 每日签到: POST /v2/billing/meter/daily-checkin
+- 刷新令牌: POST /v2/plugin/auth/token/refresh
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _pick_bool(data: Dict[str, Any], snake: str, camel: str, default: bool) -> bool:
+    """从响应中宽松读取布尔值，兼容 true/1/'true' 等写法"""
+    raw = data.get(snake, data.get(camel))
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        lower = raw.strip().lower()
+        if lower in ('true', '1'):
+            return True
+        if lower in ('false', '0'):
+            return False
+    return default
+
+
+def _pick_int(data: Dict[str, Any], snake: str, camel: str) -> Optional[int]:
+    """从响应中宽松读取整数值，兼容下划线和驼峰命名"""
+    raw = data.get(snake, data.get(camel))
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, str) and raw.strip().lstrip('-').isdigit():
+        return int(raw.strip())
+    return None
+
+
+class WorkBuddyAPI:
+    """WorkBuddy API类"""
+
+    BASE_URL = 'https://www.codebuddy.cn'
+    API_PREFIX = '/v2/plugin'
+
+    # 网关会拒绝缺少浏览器 UA 的请求（403 / code=10085），与 cockpit-tools 保持一致
+    DEFAULT_USER_AGENT = (
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    )
+
+    # 签到状态接口，按顺序尝试，前者失败时回退到后者
+    CHECKIN_STATUS_PATHS = [
+        '/v2/billing/meter/checkin-activity-status',
+        '/v2/billing/meter/checkin-status',
+    ]
+    DAILY_CHECKIN_PATH = '/v2/billing/meter/daily-checkin'
+
+    def __init__(
+        self,
+        access_token: str,
+        refresh_token: Optional[str] = None,
+        uid: Optional[str] = None,
+        enterprise_id: Optional[str] = None,
+        domain: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        """
+        初始化API类
+
+        Args:
+            access_token (str): 访问令牌
+            refresh_token (Optional[str]): 刷新令牌，用于令牌过期时自动续期
+            uid (Optional[str]): 用户ID，对应请求头 X-User-Id
+            enterprise_id (Optional[str]): 企业ID，对应请求头 X-Enterprise-Id / X-Tenant-Id
+            domain (Optional[str]): 域名，对应请求头 X-Domain
+            user_agent (Optional[str]): 用户代理字符串，可选
+            timeout (int): 请求超时时间（秒）
+        """
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.uid = uid
+        self.enterprise_id = enterprise_id
+        self.domain = domain
+        self.timeout = timeout
+        self.user_agent = user_agent or self.DEFAULT_USER_AGENT
+        # 令牌被刷新过时置为True，供上层决定是否回写配置文件
+        self.token_refreshed = False
+
+    def _build_headers(self) -> Dict[str, str]:
+        """
+        构造请求头，与官方 buildHeaders(session) 对齐
+
+        Returns:
+            Dict[str, str]: 请求头字典
+        """
+        headers = {
+            'Authorization': f'Bearer {self.access_token}',
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'User-Agent': self.user_agent,
+        }
+
+        if self.uid:
+            headers['X-User-Id'] = self.uid
+        if self.enterprise_id:
+            headers['X-Enterprise-Id'] = self.enterprise_id
+            headers['X-Tenant-Id'] = self.enterprise_id
+        if self.domain:
+            headers['X-Domain'] = self.domain
+
+        return headers
+
+    def _post(self, path: str, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        """
+        发送POST请求并解析统一响应结构
+
+        Args:
+            path (str): 接口路径
+            extra_headers (Optional[Dict[str, str]]): 额外请求头
+
+        Returns:
+            Dict[str, Any]: 包含success/data/error/error_type的结果字典
+        """
+        url = f'{self.BASE_URL}{path}'
+        headers = self._build_headers()
+        if extra_headers:
+            headers.update(extra_headers)
+
+        try:
+            response = requests.post(url, headers=headers, json={}, timeout=self.timeout)
+        except requests.RequestException as e:
+            return {'success': False, 'error': f'请求 {path} 失败: {e}', 'error_type': 'network'}
+
+        # 401/403 视为令牌失效
+        if response.status_code in (401, 403):
+            return {
+                'success': False,
+                'error': f'令牌已失效 (http={response.status_code})',
+                'error_type': 'token_expired',
+            }
+
+        try:
+            body = response.json()
+        except ValueError:
+            return {
+                'success': False,
+                'error': f'解析 {path} 响应失败: {response.text[:200]}',
+                'error_type': 'parse',
+            }
+
+        message = body.get('message') or body.get('msg') or 'unknown error'
+
+        if not response.ok:
+            return {
+                'success': False,
+                'error': f'请求 {path} 失败 (http={response.status_code}): {message}',
+                'error_type': 'http',
+            }
+
+        # 与官方保持一致：仅 code == 0 视为成功
+        code = body.get('code', -1)
+        if code != 0:
+            error_type = 'business'
+            if code in (401, 403) or '登录' in str(message) or 'token' in str(message).lower():
+                error_type = 'token_expired'
+            return {
+                'success': False,
+                'error': f'{message} (code={code})',
+                'error_type': error_type,
+                'code': code,
+                'body': body,
+            }
+
+        if 'data' not in body:
+            return {
+                'success': False,
+                'error': f'{path} 响应缺少 data 字段',
+                'error_type': 'parse',
+            }
+
+        return {'success': True, 'data': body.get('data') or {}}
+
+    def refresh_access_token(self) -> Dict[str, Any]:
+        """
+        使用refresh_token换取新的access_token
+
+        Returns:
+            Dict[str, Any]: 包含success和新令牌信息的结果字典
+        """
+        if not self.refresh_token:
+            return {'success': False, 'error': '账号未配置 refresh_token，无法自动续期'}
+
+        result = self._post(
+            f'{self.API_PREFIX}/auth/token/refresh',
+            extra_headers={'X-Refresh-Token': self.refresh_token},
+        )
+
+        if not result['success']:
+            return {'success': False, 'error': result.get('error', '刷新令牌失败')}
+
+        data = result['data']
+        new_access_token = data.get('accessToken') or data.get('access_token')
+        if not new_access_token:
+            return {'success': False, 'error': '刷新响应中缺少 accessToken'}
+
+        self.access_token = new_access_token
+        self.refresh_token = data.get('refreshToken') or data.get('refresh_token') or self.refresh_token
+        self.domain = data.get('domain') or self.domain
+        self.token_refreshed = True
+
+        expires_at = data.get('expiresAt') or data.get('expires_at')
+        logger.info('🔄 访问令牌已刷新')
+
+        return {
+            'success': True,
+            'access_token': self.access_token,
+            'refresh_token': self.refresh_token,
+            'expires_at': expires_at,
+            'domain': self.domain,
+        }
+
+    def _post_with_retry(self, path: str) -> Dict[str, Any]:
+        """
+        发送POST请求，遇到令牌过期时自动刷新后重试一次
+
+        Args:
+            path (str): 接口路径
+
+        Returns:
+            Dict[str, Any]: 请求结果字典
+        """
+        result = self._post(path)
+
+        if result['success'] or result.get('error_type') != 'token_expired':
+            return result
+
+        if not self.refresh_token:
+            return result
+
+        logger.info('⚠️ 令牌已过期，尝试自动刷新...')
+        refresh_result = self.refresh_access_token()
+        if not refresh_result['success']:
+            return {
+                'success': False,
+                'error': f"令牌过期且刷新失败: {refresh_result.get('error')}",
+                'error_type': 'token_expired',
+            }
+
+        return self._post(path)
+
+    def get_checkin_status(self) -> Dict[str, Any]:
+        """
+        查询今日签到状态
+
+        优先请求 checkin-activity-status（Buddy加油站），失败后回退到 checkin-status
+
+        Returns:
+            Dict[str, Any]: 包含签到状态各字段的结果字典
+        """
+        errors: List[str] = []
+
+        for path in self.CHECKIN_STATUS_PATHS:
+            result = self._post_with_retry(path)
+
+            if result['success']:
+                return self._parse_checkin_status(result['data'])
+
+            errors.append(result.get('error', '未知错误'))
+
+            # 令牌问题无需继续回退，直接返回
+            if result.get('error_type') == 'token_expired':
+                return {
+                    'success': False,
+                    'error': result.get('error'),
+                    'error_type': 'token_expired',
+                }
+
+        return {
+            'success': False,
+            'error': '查询签到状态失败: ' + ' | '.join(errors),
+            'error_type': 'api',
+        }
+
+    @staticmethod
+    def _parse_checkin_status(data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        解析签到状态数据，兼容下划线与驼峰两种命名
+
+        Args:
+            data (Dict[str, Any]): 接口返回的data字段
+
+        Returns:
+            Dict[str, Any]: 标准化后的签到状态
+        """
+        if not isinstance(data, dict):
+            data = {}
+
+        return {
+            'success': True,
+            # 缺省按已激活处理：有data即认为活动可用，显式false才视为关闭
+            'active': _pick_bool(data, 'active', 'Active', True),
+            'today_checked_in': _pick_bool(data, 'today_checked_in', 'todayCheckedIn', False),
+            'streak_days': _pick_int(data, 'streak_days', 'streakDays') or 0,
+            'daily_credit': _pick_int(data, 'daily_credit', 'dailyCredit') or 0,
+            'today_credit': _pick_int(data, 'today_credit', 'todayCredit'),
+            'next_streak_day': _pick_int(data, 'next_streak_day', 'nextStreakDay'),
+            'is_streak_day': _pick_bool(data, 'is_streak_day', 'isStreakDay', False),
+            'streak_bonus_days': _pick_int(data, 'streak_bonus_days', 'streakBonusDays'),
+            'streak_bonus_credit': _pick_int(data, 'streak_bonus_credit', 'streakBonusCredit'),
+            'checkin_dates': data.get('checkin_dates') or data.get('checkinDates') or [],
+            'raw': data,
+        }
+
+    def daily_checkin(self) -> Dict[str, Any]:
+        """
+        执行每日签到
+
+        Returns:
+            Dict[str, Any]: 包含签到结果、获得积分、连签天数的结果字典
+        """
+        result = self._post_with_retry(self.DAILY_CHECKIN_PATH)
+
+        if not result['success']:
+            # code != 0 属于业务错误（如今日已签到），保留原始信息交由上层判断
+            return {
+                'success': False,
+                'error': result.get('error', '签到失败'),
+                'error_type': result.get('error_type', 'api'),
+            }
+
+        data = result['data']
+        if not isinstance(data, dict):
+            data = {}
+
+        # code == 0 时若未显式返回 success 字段，默认视为成功
+        success = data.get('success', True)
+        credit = _pick_int(data, 'credit', 'today_credit')
+        if credit is None:
+            credit = _pick_int(data, 'todayCredit', 'credit')
+
+        return {
+            'success': bool(success),
+            'message': data.get('message') or ('签到成功' if success else '签到失败'),
+            'credit': credit,
+            'streak_days': _pick_int(data, 'streak_days', 'streakDays'),
+            'is_streak_day': _pick_bool(data, 'is_streak_day', 'isStreakDay', False),
+            'next_checkin_in': _pick_int(data, 'next_checkin_in', 'nextCheckinIn'),
+            'reward': data.get('reward'),
+            'raw': data,
+        }

--- a/script/workbuddy/import_accounts.py
+++ b/script/workbuddy/import_accounts.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WorkBuddy账号导入工具
+
+将 cockpit-tools (https://github.com/jlcodes99/cockpit-tools) 管理的 WorkBuddy 账号
+批量导入到本项目的 config/token.json 中的 workbuddy 节点。
+
+支持的导入来源：
+1. 自动探测本机 cockpit-tools 数据目录（默认行为）
+2. 指定 cockpit-tools 数据目录或 workbuddy_accounts 目录
+3. 指定单个账号 JSON 文件，或包含账号数组的 JSON 文件
+
+账号存储兼容两种格式：
+- 明文：直接包含 access_token 字段
+- 加密：cockpit-tools 新版使用 AES-256-GCM 加密（字段 ciphertext/nonce），
+       本工具会用本机 secure-account-storage.key 自动解密
+
+使用示例：
+    python import_accounts.py                      # 自动探测并导入
+    python import_accounts.py --list               # 仅预览，不写入配置
+    python import_accounts.py --path D:/xxx.json   # 从指定文件导入
+    python import_accounts.py --path D:/xxx/dir    # 从指定目录导入
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+project_root = Path(__file__).resolve().parent.parent.parent
+CONFIG_PATH = project_root / "config" / "token.json"
+
+# cockpit-tools 中的账号索引文件与详情目录名
+ACCOUNTS_INDEX_FILE = "workbuddy_accounts.json"
+ACCOUNTS_DIR_NAME = "workbuddy_accounts"
+# 加密账号使用的本地密钥文件名
+KEY_FILE_NAME = "secure-account-storage.key"
+
+try:
+    from Crypto.Cipher import AES
+    HAS_CRYPTO = True
+except ImportError:
+    HAS_CRYPTO = False
+
+
+def find_cockpit_data_dirs() -> List[Path]:
+    """
+    自动探测本机可能存在的 cockpit-tools 数据目录
+
+    Returns:
+        List[Path]: 包含 WorkBuddy 账号数据的候选目录列表
+    """
+    candidates: List[Path] = []
+    home = Path.home()
+
+    # 各平台应用数据根目录
+    roots: List[Path] = []
+    if sys.platform == 'win32':
+        for env_key in ('APPDATA', 'LOCALAPPDATA'):
+            value = os.environ.get(env_key)
+            if value:
+                roots.append(Path(value))
+        # 家目录本身（cockpit-tools 数据可能在 C:/Users/xxx/.antigravity_cockpit）
+        roots.append(home)
+        roots.append(home / '.config')
+        roots.append(home / '.local' / 'share')
+    elif sys.platform == 'darwin':
+        roots.append(home / 'Library' / 'Application Support')
+        roots.append(home)
+    else:
+        roots.append(home / '.config')
+        roots.append(home / '.local' / 'share')
+        roots.append(home)
+
+    for root in roots:
+        if not root.is_dir():
+            continue
+        try:
+            for child in root.iterdir():
+                if not child.is_dir():
+                    continue
+                name = child.name.lower()
+                if 'cockpit' in name or 'agtools' in name or 'antigravity' in name:
+                    if (child / ACCOUNTS_INDEX_FILE).exists() or (child / ACCOUNTS_DIR_NAME).is_dir():
+                        candidates.append(child)
+        except PermissionError:
+            continue
+
+    return candidates
+
+
+def find_secure_key(source_dir: Path) -> Optional[Path]:
+    """
+    为给定账号来源目录查找解密用的本地密钥文件
+
+    优先在来源目录及其上级目录查找，最后回退到常见的家目录路径。
+
+    Args:
+        source_dir (Path): 账号来源目录（可能是 cockpit 数据目录或 workbuddy_accounts 目录）
+
+    Returns:
+        Optional[Path]: 密钥文件路径，未找到返回 None
+    """
+    search_bases: List[Path] = [source_dir]
+    if source_dir.name == ACCOUNTS_DIR_NAME:
+        search_bases.append(source_dir.parent)
+    else:
+        search_bases.append(source_dir / ACCOUNTS_DIR_NAME)
+    search_bases.append(source_dir.parent)
+
+    for base in search_bases:
+        candidate = base / KEY_FILE_NAME
+        if candidate.is_file():
+            return candidate
+
+    # 回退：家目录下的常见位置
+    home = Path.home()
+    for fallback in (
+        home / '.antigravity_cockpit' / KEY_FILE_NAME,
+        home / '.config' / 'cockpit-tools' / KEY_FILE_NAME,
+        home / '.local' / 'share' / 'cockpit-tools' / KEY_FILE_NAME,
+    ):
+        if fallback.is_file():
+            return fallback
+
+    return None
+
+
+def decrypt_record(enc: Dict[str, Any], key: bytes) -> Optional[Dict[str, Any]]:
+    """
+    使用本地密钥解密 AES-256-GCM 加密的账号记录
+
+    Args:
+        enc (Dict[str, Any]): 含 ciphertext/nonce 的加密记录
+        key (bytes): 32 字节 AES 密钥
+
+    Returns:
+        Optional[Dict[str, Any]]: 解密后的明文账号数据，失败返回 None
+    """
+    if not HAS_CRYPTO:
+        return None
+    try:
+        nonce = base64.b64decode(enc['nonce'])
+        ct = base64.b64decode(enc['ciphertext'])
+        # GCM 认证标签为密文末尾 16 字节
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        plain = cipher.decrypt_and_verify(ct[:-16], ct[-16:])
+        return json.loads(plain.decode('utf-8'))
+    except Exception as e:
+        print(f"⚠️  解密失败: {e}")
+        return None
+
+
+def load_accounts_from_dir(directory: Path) -> List[Dict[str, Any]]:
+    """
+    从目录中读取 WorkBuddy 账号详情
+
+    兼容两种传入方式：cockpit-tools 数据目录，或直接是 workbuddy_accounts 目录。
+    同时兼容明文与 AES-256-GCM 加密两种存储格式。
+
+    Args:
+        directory (Path): 目录路径
+
+    Returns:
+        List[Dict[str, Any]]: 原始账号数据列表
+    """
+    accounts_dir = directory / ACCOUNTS_DIR_NAME
+    if not accounts_dir.is_dir():
+        accounts_dir = directory
+
+    if not accounts_dir.is_dir():
+        return []
+
+    key_path = find_secure_key(directory)
+    key = None
+    if key_path:
+        try:
+            key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
+        except Exception as e:
+            print(f"⚠️  读取密钥失败: {e}")
+
+    accounts: List[Dict[str, Any]] = []
+    for json_file in sorted(accounts_dir.glob('*.json')):
+        if json_file.name == ACCOUNTS_INDEX_FILE:
+            continue
+        try:
+            with open(json_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"⚠️  跳过无法解析的文件 {json_file.name}: {e}")
+            continue
+
+        # 加密格式：含 ciphertext 字段
+        if isinstance(data, dict) and data.get('ciphertext') and key:
+            data = decrypt_record(data, key)
+            if not data:
+                continue
+
+        if isinstance(data, dict) and data.get('access_token'):
+            accounts.append(data)
+
+    return accounts
+
+
+def load_accounts_from_file(file_path: Path) -> List[Dict[str, Any]]:
+    """
+    从单个 JSON 文件读取账号，支持单对象、数组以及 {"accounts": [...]} 结构
+
+    Args:
+        file_path (Path): JSON 文件路径
+
+    Returns:
+        List[Dict[str, Any]]: 原始账号数据列表
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"❌ 读取文件失败: {e}")
+        return []
+
+    if isinstance(data, dict):
+        # 单文件加密记录
+        if data.get('ciphertext'):
+            key_path = find_secure_key(file_path.parent)
+            if key_path:
+                key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
+                dec = decrypt_record(data, key)
+                if dec:
+                    data = dec
+        if isinstance(data.get('accounts'), list):
+            data = data['accounts']
+        else:
+            data = [data]
+
+    if not isinstance(data, list):
+        return []
+
+    return [item for item in data if isinstance(item, dict) and item.get('access_token')]
+
+
+def convert_account(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    将 cockpit-tools 账号结构转换为本项目配置结构
+
+    Args:
+        raw (Dict[str, Any]): cockpit-tools 的账号数据
+
+    Returns:
+        Optional[Dict[str, Any]]: 转换后的账号配置，缺少令牌时返回None
+    """
+    access_token = raw.get('access_token')
+    if not access_token:
+        return None
+
+    account_name = raw.get('nickname') or raw.get('email') or raw.get('id') or '未命名账号'
+
+    account: Dict[str, Any] = {
+        'account_name': account_name,
+        'email': raw.get('email', ''),
+        'access_token': access_token,
+    }
+
+    # 可选字段仅在有值时写入，避免配置中出现大量空串
+    for key in ('refresh_token', 'uid', 'enterprise_id', 'domain'):
+        value = raw.get(key)
+        if value:
+            account[key] = value
+
+    return account
+
+
+def account_identity(account: Dict[str, Any]) -> str:
+    """
+    生成账号唯一标识，用于导入时去重
+
+    Args:
+        account (Dict[str, Any]): 账号配置
+
+    Returns:
+        str: 唯一标识
+    """
+    return (account.get('uid') or account.get('email') or account.get('account_name') or '').strip().lower()
+
+
+def merge_into_config(new_accounts: List[Dict[str, Any]], config_path: Path) -> Dict[str, int]:
+    """
+    将账号合并写入配置文件的 workbuddy 节点
+
+    已存在的账号会更新令牌，不存在的账号追加写入
+
+    Args:
+        new_accounts (List[Dict[str, Any]]): 待导入的账号列表
+        config_path (Path): 配置文件路径
+
+    Returns:
+        Dict[str, int]: 包含added和updated数量的统计字典
+    """
+    if config_path.exists():
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config_data = json.load(f)
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_data = {}
+
+    workbuddy_node = config_data.setdefault('workbuddy', {})
+    existing: List[Dict[str, Any]] = workbuddy_node.setdefault('accounts', [])
+
+    index_map = {account_identity(acc): idx for idx, acc in enumerate(existing) if account_identity(acc)}
+
+    added = 0
+    updated = 0
+
+    for account in new_accounts:
+        identity = account_identity(account)
+        if identity and identity in index_map:
+            target = existing[index_map[identity]]
+            # 保留用户自定义的账号名称，只更新令牌等认证信息
+            for key, value in account.items():
+                if key == 'account_name':
+                    continue
+                target[key] = value
+            updated += 1
+        else:
+            existing.append(account)
+            if identity:
+                index_map[identity] = len(existing) - 1
+            added += 1
+
+    with open(config_path, 'w', encoding='utf-8') as f:
+        json.dump(config_data, f, ensure_ascii=False, indent=2)
+
+    return {'added': added, 'updated': updated}
+
+
+def collect_accounts() -> List[Dict[str, Any]]:
+    """
+    自动探测 cockpit-tools 数据目录并采集账号（已转换、去重）
+
+    Returns:
+        List[Dict[str, Any]]: 转换后的账号配置列表，无可用来源时返回空列表
+    """
+    candidates = find_cockpit_data_dirs()
+    if not candidates:
+        return []
+
+    raw_accounts: List[Dict[str, Any]] = []
+    for candidate in candidates:
+        raw_accounts.extend(load_accounts_from_dir(candidate))
+
+    accounts: List[Dict[str, Any]] = []
+    seen = set()
+    for raw in raw_accounts:
+        converted = convert_account(raw)
+        if not converted:
+            continue
+        identity = account_identity(converted)
+        if identity and identity in seen:
+            continue
+        if identity:
+            seen.add(identity)
+        accounts.append(converted)
+
+    return accounts
+
+
+def sync_accounts(config_path: Optional[Path] = None, quiet: bool = False) -> Optional[Dict[str, int]]:
+    """
+    从本机 cockpit-tools 同步账号到配置文件（签到前的自动刷新入口）
+
+    自动探测数据目录、读取并解密账号、去重后合并写入配置。
+    任何异常都不抛出，保证不影响签到主流程。
+
+    Args:
+        config_path (Optional[Path]): 配置文件路径，默认项目根目录 config/token.json
+        quiet (bool): True 时不输出任何提示信息
+
+    Returns:
+        Optional[Dict[str, int]]: 同步统计 {'added': n, 'updated': n}；
+                                  未找到 cockpit-tools 或无账号时返回 None
+    """
+    log = (lambda *a, **k: None) if quiet else print
+    try:
+        accounts = collect_accounts()
+        if not accounts:
+            return None
+        stats = merge_into_config(accounts, config_path or CONFIG_PATH)
+        log(f"✅ 同步完成: 新增 {stats['added']} 个，更新 {stats['updated']} 个")
+        return stats
+    except Exception as e:
+        log(f"⚠️  同步失败（不影响签到）: {e}")
+        return None
+
+
+def main():
+    """主函数"""
+    parser = argparse.ArgumentParser(description='WorkBuddy账号导入工具')
+    parser.add_argument('--path', help='指定 cockpit-tools 数据目录或账号 JSON 文件路径')
+    parser.add_argument('--list', action='store_true', help='仅预览待导入账号，不写入配置文件')
+    parser.add_argument('--config', help=f'指定配置文件路径，默认 {CONFIG_PATH}')
+    args = parser.parse_args()
+
+    config_path = Path(args.config) if args.config else CONFIG_PATH
+
+    if args.path:
+        source = Path(args.path).expanduser()
+        if not source.exists():
+            print(f"❌ 路径不存在: {source}")
+            sys.exit(1)
+
+        if source.is_dir():
+            raw_accounts = load_accounts_from_dir(source)
+        else:
+            raw_accounts = load_accounts_from_file(source)
+
+        print(f"📂 来源: {source}")
+
+        accounts: List[Dict[str, Any]] = []
+        seen = set()
+        for raw in raw_accounts:
+            converted = convert_account(raw)
+            if not converted:
+                continue
+            identity = account_identity(converted)
+            if identity and identity in seen:
+                continue
+            if identity:
+                seen.add(identity)
+            accounts.append(converted)
+    else:
+        print("🔍 正在自动探测 cockpit-tools 数据目录...")
+        candidates = find_cockpit_data_dirs()
+
+        if not candidates:
+            print("❌ 未找到 cockpit-tools 数据目录")
+            print("   请使用 --path 手动指定账号目录或导出的 JSON 文件，例如：")
+            print("   python import_accounts.py --path \"C:/Users/你的用户名/.antigravity_cockpit\"")
+            sys.exit(1)
+
+        for candidate in candidates:
+            found = load_accounts_from_dir(candidate)
+            if found:
+                print(f"📂 来源: {candidate} (发现 {len(found)} 个账号)")
+        accounts = collect_accounts()
+
+    if not accounts:
+        print("❌ 未找到任何包含 access_token 的账号数据")
+        sys.exit(1)
+
+    print(f"\n共解析到 {len(accounts)} 个账号:")
+    for idx, account in enumerate(accounts, 1):
+        token_preview = account['access_token'][:12] + '...'
+        print(f"  {idx}. {account['account_name']} | {account.get('email', '-')} | token: {token_preview}")
+
+    if args.list:
+        print("\n👀 预览模式，未写入配置文件")
+        return
+
+    stats = merge_into_config(accounts, config_path)
+    print(f"\n✅ 导入完成: 新增 {stats['added']} 个，更新 {stats['updated']} 个")
+    print(f"📝 配置文件: {config_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/script/workbuddy/main.py
+++ b/script/workbuddy/main.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+new Env('WorkBuddy签到');
+cron: 30 8 * * *
+"""
+
+"""
+WorkBuddy(CodeBuddy)自动签到脚本
+
+该脚本用于自动执行WorkBuddy的每日签到任务，包括：
+- 读取账号配置信息
+- 查询今日签到状态
+- 执行签到操作
+- 令牌过期时自动刷新并回写配置
+- 推送执行结果
+
+Author: Assistant
+Date: 2026-08-03
+"""
+
+import json
+import logging
+import os
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+# 获取项目根目录
+project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from api import WorkBuddyAPI
+from import_accounts import sync_accounts
+from notification import send_notification, NotificationSound
+
+# 启动随机延迟上限（秒）：在窗口内随机错开请求，避免与他人撞车；设为 0 关闭
+JITTER_MAX_SECONDS = int(os.environ.get('WORKBUDDY_JITTER_MAX', '600'))
+
+
+class WorkBuddyTasks:
+    """WorkBuddy签到任务自动化执行类"""
+
+    def __init__(self, config_path: str = None):
+        """
+        初始化任务执行器
+
+        Args:
+            config_path (str): 配置文件的完整路径，如果为None则使用项目根目录下的config/token.json
+        """
+        if config_path is None:
+            self.config_path = project_root / "config" / "token.json"
+        else:
+            self.config_path = Path(config_path)
+
+        self.accounts: List[Dict[str, Any]] = []
+        self.logger = self._setup_logger()
+        self._init_accounts()
+        self.account_results: List[Dict[str, Any]] = []
+
+    def _setup_logger(self) -> logging.Logger:
+        """
+        设置日志记录器
+
+        Returns:
+            logging.Logger: 配置好的日志记录器
+        """
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        console_handler.setFormatter(formatter)
+
+        if not logger.handlers:
+            logger.addHandler(console_handler)
+
+        return logger
+
+    def _init_accounts(self):
+        """从配置文件中读取账号信息"""
+        if not self.config_path.exists():
+            self.logger.error(f"配置文件不存在: {self.config_path}")
+            raise FileNotFoundError(f"配置文件不存在: {self.config_path}")
+
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+                # 从统一配置文件的 workbuddy 节点读取
+                workbuddy_config = config_data.get('workbuddy', {})
+                self.accounts = workbuddy_config.get('accounts', [])
+
+            if not self.accounts:
+                self.logger.warning("配置文件中没有找到 workbuddy 账号信息")
+            else:
+                self.logger.info(f"成功加载 {len(self.accounts)} 个账号配置")
+
+        except json.JSONDecodeError as e:
+            self.logger.error(f"配置文件JSON解析失败: {e}")
+            raise
+        except Exception as e:
+            self.logger.error(f"读取配置文件失败: {e}")
+            raise
+
+    def _save_refreshed_token(self, account_index: int, api: WorkBuddyAPI):
+        """
+        令牌刷新后回写配置文件，避免下次执行仍使用过期令牌
+
+        Args:
+            account_index (int): 账号在配置数组中的下标
+            api (WorkBuddyAPI): 持有最新令牌的API实例
+        """
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+
+            accounts = config_data.get('workbuddy', {}).get('accounts', [])
+            if account_index >= len(accounts):
+                self.logger.warning("⚠️ 账号下标越界，跳过令牌回写")
+                return
+
+            accounts[account_index]['access_token'] = api.access_token
+            if api.refresh_token:
+                accounts[account_index]['refresh_token'] = api.refresh_token
+            if api.domain:
+                accounts[account_index]['domain'] = api.domain
+
+            with open(self.config_path, 'w', encoding='utf-8') as f:
+                json.dump(config_data, f, ensure_ascii=False, indent=2)
+
+            self.logger.info("💾 新令牌已写回配置文件")
+
+        except Exception as e:
+            self.logger.warning(f"⚠️ 回写令牌失败: {e}")
+
+    def process_account(self, account_index: int, account_info: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        处理单个账号的签到任务
+
+        Args:
+            account_index (int): 账号在配置数组中的下标
+            account_info (Dict[str, Any]): 账号信息字典
+
+        Returns:
+            Dict[str, Any]: 处理结果
+        """
+        account_name = account_info.get('account_name') or account_info.get('email') or '未命名账号'
+        self.logger.info(f"\n{'=' * 60}")
+        self.logger.info(f"开始处理账号: {account_name}")
+        self.logger.info(f"{'=' * 60}")
+
+        result = {
+            'account_name': account_name,
+            'success': False,
+            'message': '',
+            'already_checked': False,
+            'credit': None,
+            'streak_days': None,
+            'status_info': {}
+        }
+
+        try:
+            access_token = account_info.get('access_token')
+            if not access_token:
+                error_msg = "账号配置中缺少 access_token"
+                self.logger.error(f"❌ {account_name}: {error_msg}")
+                result['message'] = error_msg
+                return result
+
+            api = WorkBuddyAPI(
+                access_token=access_token,
+                refresh_token=account_info.get('refresh_token'),
+                uid=account_info.get('uid'),
+                enterprise_id=account_info.get('enterprise_id'),
+                domain=account_info.get('domain'),
+                user_agent=account_info.get('user_agent'),
+            )
+
+            # 查询签到状态
+            self.logger.info(f"{account_name} - 查询签到状态")
+            status = api.get_checkin_status()
+
+            if not status['success']:
+                error_msg = status.get('error', '查询签到状态失败')
+                if status.get('error_type') == 'token_expired':
+                    result['message'] = '令牌已过期，请重新导入账号'
+                    self.logger.error(f"❌ {account_name} 令牌已过期，请重新导入账号")
+                else:
+                    result['message'] = error_msg
+                    self.logger.error(f"❌ {account_name} {error_msg}")
+                return result
+
+            result['status_info'] = status
+            self.logger.info(
+                f"📊 连签天数: {status.get('streak_days', 0)} 天 | "
+                f"每日积分: {status.get('daily_credit', 0)}"
+            )
+
+            # 活动未开启
+            if not status.get('active', True):
+                result['success'] = True
+                result['message'] = '签到活动未开启或不适用'
+                self.logger.info(f"ℹ️ {account_name} 签到活动未开启")
+                return result
+
+            # 今日已签到
+            if status.get('today_checked_in'):
+                result['success'] = True
+                result['already_checked'] = True
+                result['message'] = '今日已签到'
+                result['credit'] = status.get('today_credit')
+                result['streak_days'] = status.get('streak_days')
+                self.logger.info(f"✅ {account_name} 今日已签到")
+                return result
+
+            # 执行签到
+            self.logger.info(f"{account_name} - 执行签到")
+            checkin = api.daily_checkin()
+
+            if checkin['success']:
+                result['success'] = True
+                result['message'] = checkin.get('message') or '签到成功'
+                result['credit'] = checkin.get('credit')
+                result['streak_days'] = checkin.get('streak_days')
+
+                self.logger.info(f"✅ {account_name} 签到成功")
+                if checkin.get('credit') is not None:
+                    self.logger.info(f"🎁 获得积分: {checkin['credit']}")
+                if checkin.get('streak_days') is not None:
+                    self.logger.info(f"🔥 连签天数: {checkin['streak_days']} 天")
+                if checkin.get('is_streak_day'):
+                    self.logger.info("🎉 触发连签奖励")
+            else:
+                # 签到失败后复查状态，可能是并发导致的"已签到"
+                latest = api.get_checkin_status()
+                if latest['success'] and latest.get('today_checked_in'):
+                    result['success'] = True
+                    result['already_checked'] = True
+                    result['message'] = '今日已签到'
+                    result['streak_days'] = latest.get('streak_days')
+                    self.logger.info(f"✅ {account_name} 今日已签到")
+                else:
+                    result['message'] = checkin.get('error', '签到失败')
+                    self.logger.error(f"❌ {account_name} 签到失败: {result['message']}")
+
+            # 令牌被刷新过则回写配置
+            if api.token_refreshed:
+                self._save_refreshed_token(account_index, api)
+
+        except Exception as e:
+            error_msg = f"处理账号时发生异常: {str(e)}"
+            self.logger.error(f"❌ {error_msg}")
+            result['message'] = error_msg
+            import traceback
+            traceback.print_exc()
+
+        return result
+
+    def run(self):
+        """执行所有账号的签到任务"""
+        # 签到前先从本机 cockpit-tools 同步最新令牌（未安装则跳过），避免双端令牌轮换导致 401
+        sync_stats = sync_accounts(quiet=True)
+        if sync_stats:
+            self.logger.info(
+                f"🔄 已从 cockpit-tools 同步账号: 新增 {sync_stats['added']}，更新 {sync_stats['updated']}"
+            )
+            self._init_accounts()
+
+        # 启动随机抖动，错开请求高峰
+        if JITTER_MAX_SECONDS > 0:
+            delay = random.uniform(0, JITTER_MAX_SECONDS)
+            self.logger.info(f"⏱️  随机延迟 {delay:.0f} 秒后开始（可通过环境变量 WORKBUDDY_JITTER_MAX 调整）")
+            time.sleep(delay)
+
+        self.logger.info("=" * 60)
+        self.logger.info("WorkBuddy自动签到任务开始")
+        self.logger.info("=" * 60)
+
+        if not self.accounts:
+            self.logger.warning("没有需要处理的账号")
+            return
+
+        for idx, account_info in enumerate(self.accounts):
+            result = self.process_account(idx, account_info)
+            self.account_results.append(result)
+
+            # 处理完一个账号后，如果还有下一个账号，则等待5-10秒
+            if idx < len(self.accounts) - 1:
+                delay = random.uniform(5, 10)
+                self.logger.info(f"\n⏱️  等待 {delay:.1f} 秒后处理下一个账号...")
+                time.sleep(delay)
+
+        self._print_summary()
+        self._send_notification()
+
+    def _print_summary(self):
+        """打印执行结果统计"""
+        self.logger.info("\n" + "=" * 60)
+        self.logger.info("执行结果统计")
+        self.logger.info("=" * 60)
+
+        total = len(self.account_results)
+        success = sum(1 for r in self.account_results if r['success'])
+        already = sum(1 for r in self.account_results if r.get('already_checked'))
+        failed = total - success
+
+        self.logger.info(f"总账号数: {total}")
+        self.logger.info(f"签到成功: {success - already}")
+        self.logger.info(f"今日已签: {already}")
+        self.logger.info(f"签到失败: {failed}")
+
+        self.logger.info("\n详细结果:")
+        for result in self.account_results:
+            status = "✅ 成功" if result['success'] else "❌ 失败"
+            self.logger.info(f"  {result['account_name']}: {status} - {result['message']}")
+
+        self.logger.info("=" * 60)
+
+    def _send_notification(self):
+        """发送推送通知"""
+        if not self.account_results:
+            return
+
+        total = len(self.account_results)
+        success = sum(1 for r in self.account_results if r['success'])
+        already = sum(1 for r in self.account_results if r.get('already_checked'))
+        failed = total - success
+
+        title = "WorkBuddy签到结果通知"
+
+        content_lines = [
+            f"📊 总账号数: {total}",
+            f"✅ 签到成功: {success - already}",
+            f"📅 今日已签: {already}",
+            f"❌ 签到失败: {failed}",
+            "",
+            "📋 详细结果:"
+        ]
+
+        for result in self.account_results:
+            status = "✅" if result['success'] else "❌"
+            content_lines.append(f"{status} {result['account_name']}: {result['message']}")
+
+            detail_parts = []
+            if result.get('credit') is not None:
+                detail_parts.append(f"积分 +{result['credit']}")
+            if result.get('streak_days') is not None:
+                detail_parts.append(f"连签 {result['streak_days']} 天")
+            if detail_parts:
+                content_lines.append(f"    🎁 {' | '.join(detail_parts)}")
+
+        content = "\n".join(content_lines)
+
+        try:
+            send_notification(
+                title=title,
+                content=content,
+                sound=NotificationSound.BIRDSONG
+            )
+            self.logger.info("✅ 推送通知已发送")
+        except Exception as e:
+            self.logger.warning(f"⚠️ 发送推送通知失败: {str(e)}")
+
+
+def main():
+    """主函数"""
+    try:
+        tasks = WorkBuddyTasks()
+        tasks.run()
+
+    except FileNotFoundError as e:
+        print(f"❌ 错误: {e}")
+        print("请确保配置文件存在并包含 workbuddy 账号信息")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ 发生未知错误: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 功能介绍

新增 WorkBuddy（CodeBuddy）每日自动签到脚本，接口实现参考 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 项目的 `codebuddy_cn_oauth` 模块，与官方客户端行为保持一致。

## 功能清单

- **每日签到**：`POST /v2/billing/meter/daily-checkin`，签到状态查询优先 `checkin-activity-status` 并自动回退 `checkin-status`（双端点兼容）
- **智能判重**：签到前先查状态，今日已签到/活动未开启自动跳过；签到失败后复查状态，兼容并发竞态
- **令牌自动续期**：`access_token` 过期时用 `refresh_token` 自动换新并回写 `config/token.json`（实测 access_token 60 天 / refresh_token 90 天，rotation 轮换，90 天内运行一次即可无限续期）
- **账号导入工具**（`import_accounts.py`）：
  - 从**官方 WorkBuddy 客户端**一键导入当前登录账号：自动探测 `%APPDATA%/WorkBuddy/User/globalStorage/state.vscdb` 并解密凭据（Windows: Local State DPAPI 密钥 + AES-256-GCM；macOS: Keychain + PBKDF2 + AES-CBC），逻辑对齐 cockpit-tools 原版本机导入
  - 从 cockpit-tools 数据目录批量导入全部账号（含 AES-256-GCM 加密账号自动解密）
  - 支持指定 JSON 文件/目录导入，按 uid 去重并保留自定义账号名，多来源自动合并
- **自动同步**：每次签到前自动从本机官方客户端 / cockpit-tools 同步最新令牌（都没有时静默跳过），避免与 cockpit-tools 并行使用时令牌轮换冲突导致 401
- **自动错峰**：启动随机延迟 0-10 分钟（`WORKBUDDY_JITTER_MAX` 可调），账号间随机间隔 5-10 秒
- **结果推送**：复用项目统一推送模块，输出积分与连签天数
- 浏览器风格 User-Agent（网关拦截非浏览器 UA 返回 403/code=10085）

## 改动范围

- 新增 `script/workbuddy/`（main.py / api.py / import_accounts.py / README.md）
- `config/template_token.json` 增加 workbuddy 节点模板
- `README.md` 增加模块说明、脚本状态表条目与更新日志（上游原有内容未改动）

## 测试情况

- 9 个账号每日自动签到稳定运行
- 官方客户端凭据解密导入实测通过（Windows DPAPI + AES-GCM 链路）
- `python import_accounts.py --list` 预览与多来源导入合并实测通过
- 兼容青龙面板（脚本头部已含 `new Env` / `cron` 声明）与 Windows 任务计划程序

## Copilot Review 处理

6 条 review 意见已全部修复并逐条回复（见[评论](https://github.com/Cat-zaizai/ZaiZaiCat-Checkin/pull/46#issuecomment-5558868802)）。