### PR TITLE
✨ WorkBuddy 签到模块：支持从官方客户端导入账号并修复 review 意见

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ WPS 脚本目前包含两个活动页面：
 WorkBuddy（CodeBuddy）每日签到脚本，接口实现参考 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 项目，与官方客户端行为保持一致：
 
 - `script/workbuddy/api.py`：接口封装，签到状态查询（双端点回退）、每日签到、令牌刷新
-- `script/workbuddy/import_accounts.py`：账号导入工具，支持从本机 cockpit-tools 数据目录自动导入（含加密账号自动解密），也支持指定 JSON 文件导入
+- `script/workbuddy/import_accounts.py`：账号导入工具，一键导入官方 WorkBuddy 客户端当前登录账号（自动解密凭据库），也支持从 cockpit-tools 批量导入或指定 JSON 文件导入
 - `script/workbuddy/main.py`：统一入口，多账号签到编排、令牌自动续期与结果推送
 
-支持每日签到、连签奖励、多账号管理、令牌自动续期（access_token 60 天 / refresh_token 90 天，自动轮换续期），安装 cockpit-tools 的用户可在签到前自动同步最新令牌。详见 [script/workbuddy/README.md](script/workbuddy/README.md)。
+支持每日签到、连签奖励、多账号管理、令牌自动续期（access_token 60 天 / refresh_token 90 天，自动轮换续期），签到前自动同步本机官方客户端 / cockpit-tools 的最新令牌。详见 [script/workbuddy/README.md](script/workbuddy/README.md)。
 
 ## 📝 更新日志
 
@@ -68,7 +68,7 @@ WorkBuddy（CodeBuddy）每日签到脚本，接口实现参考 [cockpit-tools](
 - ✨ **新增 WorkBuddy(CodeBuddy) 自动签到模块**:
   - 📅 支持每日自动签到与连签奖励
   - 🔄 支持令牌过期自动刷新并回写配置
-  - 📥 支持从本机 cockpit-tools 一键导入账号（含加密存储自动解密）
+  - 📥 支持从官方 WorkBuddy 客户端一键导入账号（自动解密凭据库），也支持从 cockpit-tools 批量导入
   - ⏱️ 内置启动随机延迟与账号间随机间隔，自动错峰
   - 📊 签到结果通过统一推送模块通知
 

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -189,7 +189,7 @@
         "refresh_token": "你的刷新令牌",
         "uid": "你的用户ID",
         "enterprise_id": "",
-        "domain": "www.codebuddy.cn"
+        "domain": ""
       }
     ]
   }

--- a/script/workbuddy/README.md
+++ b/script/workbuddy/README.md
@@ -7,8 +7,8 @@ WorkBuddy（腾讯 CodeBuddy）每日签到脚本，支持多账号、令牌自�
 ## ✨ 功能特性
 
 - 🔐 **多账号支持** - 依次处理配置中的所有账号，账号间随机延迟 5-10 秒
-- 📥 **账号导入** - 从 cockpit-tools 批量导入账号，无需手动抄写令牌
-- 🔄 **自动同步** - 每次签到前自动从本机 cockpit-tools 拉取最新令牌（未安装则跳过）
+- 📥 **账号导入** - 一键导入官方 WorkBuddy 客户端当前登录账号，无需手动抓包；也支持从 cockpit-tools 批量导入
+- 🔄 **自动同步** - 每次签到前自动从本机官方客户端 / cockpit-tools 拉取最新令牌
 - 🔁 **令牌自动续期** - `access_token` 过期时用 `refresh_token` 自动换新并写回配置
 - 🎯 **智能判重** - 先查签到状态，今日已签到则跳过，不重复请求
 - ⏱️ **随机错峰** - 启动后在时间窗口内随机延迟，避开请求高峰
@@ -20,12 +20,12 @@ WorkBuddy（腾讯 CodeBuddy）每日签到脚本，支持多账号、令牌自�
 |------|------|
 | `main.py` | 主入口，多账号签到编排与结果推送 |
 | `api.py` | 接口封装：签到状态查询、每日签到、令牌刷新 |
-| `import_accounts.py` | 账号导入工具 |
+| `import_accounts.py` | 账号导入工具：官方客户端 / cockpit-tools / JSON 文件 |
 
 ## 📦 安装依赖
 
 ```bash
-pip install requests
+pip install requests pycryptodome
 ```
 
 ## ⚙️ 配置说明
@@ -66,15 +66,19 @@ pip install requests
 
 ## 📥 导入账号
 
-### 方式一：从 cockpit-tools 自动导入（推荐）
+### 方式一：从官方 WorkBuddy 客户端导入（推荐）
 
-如果本机装了 cockpit-tools 并已登录 WorkBuddy 账号，直接运行：
+本机登录过 [WorkBuddy / CodeBuddy](https://www.codebuddy.cn) 桌面客户端的话，直接运行：
 
 ```bash
 python import_accounts.py
 ```
 
-脚本会自动探测 cockpit-tools 的数据目录（含 `C:/Users/用户名/.antigravity_cockpit`），读取其中的账号并写入 `config/token.json`。
+脚本会自动探测官方客户端凭据库（`%APPDATA%/WorkBuddy/User/globalStorage/state.vscdb`），解密并导入**当前登录账号**，无需抓包。逻辑与 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的本机导入功能对齐（Windows 使用 DPAPI + AES-GCM 解密，macOS 使用 Keychain + AES-CBC）。
+
+### 方式二：从 cockpit-tools 导入
+
+如果本机装了 [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 并管理了多个 WorkBuddy 账号，同样直接运行 `python import_accounts.py` 即可——脚本会同时探测 cockpit-tools 数据目录（含 `C:/Users/用户名/.antigravity_cockpit`），批量导入全部账号。
 
 > **加密账号自动解密**：cockpit-tools 新版将账号以 AES-256-GCM 加密存储，密钥在本机 `secure-account-storage.key`。导入工具会自动找到该密钥并解密，无需任何额外操作。明文与加密两种格式均已兼容。
 
@@ -84,9 +88,9 @@ python import_accounts.py
 python import_accounts.py --list
 ```
 
-### 方式二：指定路径导入
+### 方式三：指定路径导入
 
-自动探测失败时（例如 cockpit-tools 装在非默认位置），手动指定目录：
+自动探测失败时（例如客户端装在非默认位置），手动指定目录：
 
 ```bash
 python import_accounts.py --path "C:/Users/你的用户名/AppData/Roaming/cockpit-tools"
@@ -100,11 +104,11 @@ python import_accounts.py --path "D:/backup/my_accounts.json"
 
 ### 导入行为说明
 
-- 按 `uid`（无则用 `email`）去重，**重复导入不会产生重复账号**
+- 按 `uid`（无则用 `email`）去重，**重复导入不会产生重复账号**（官方客户端与 cockpit-tools 来源之间同样自动合并）
 - 已存在的账号只更新令牌等认证信息，**保留你自定义的 `account_name`**
 - cockpit-tools 的索引文件 `workbuddy_accounts.json` 只有摘要没有令牌，会自动跳过
 
-### 方式三：手动填写
+### 方式四：手动填写
 
 抓包获取令牌后，按上文配置格式手动填入 `config/token.json`。
 
@@ -121,7 +125,7 @@ python import_accounts.py --path "D:/backup/my_accounts.json"
 
 ### 与 cockpit-tools 并行使用
 
-[cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的自动签到会在执行时刷新令牌（refresh token 轮换），这会使 `config/token.json` 里的旧令牌立即失效。脚本已内置应对：**每次签到前自动从本机 cockpit-tools 数据目录同步最新令牌**（未安装 cockpit-tools 时自动跳过，不影响独立使用）。若两边的自动签到都已开启，建议二选一，避免重复签到。
+[cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的自动签到会在执行时刷新令牌（refresh token 轮换），这会使 `config/token.json` 里的旧令牌立即失效。脚本已内置应对：**每次签到前自动从本机官方客户端 / cockpit-tools 同步最新令牌**（两者都没有时自动跳过，不影响独立使用）。若两边的自动签到都已开启，建议二选一，避免重复签到。
 
 ## 🚀 使用方法
 

--- a/script/workbuddy/README.md
+++ b/script/workbuddy/README.md
@@ -159,19 +159,10 @@ python main.py
 1. 打开「任务计划程序」→ 创建基本任务
 2. 触发器：每天，建议设在 `07:00`~`09:00` 之间
 3. 操作：启动程序
-   - 程序：`python` 的完整路径，例如 `D:\python312\python.exe`
-   - 参数：`main.py`
-   - 起始于：`D:\test\qiandao\script\workbuddy`
+   - 程序：`python.exe` 的完整路径
+   - 参数：`main.py` 的完整路径（如 `C:\qiandao\script\workbuddy\main.py`）
 
-> **起始于必须填写**，否则脚本找不到项目根目录下的配置文件。
-
-命令行一键创建（管理员 PowerShell，路径按实际情况替换）：
-
-```powershell
-schtasks /create /tn "WorkBuddy签到" /tr "D:\test\qiandao\script\workbuddy\run.bat" /sc daily /st 08:30 /f
-```
-
-> 已通过 `run.bat` 启动器执行，内部使用 `pythonw.exe` 静默运行（不弹黑窗口），并自动切换到脚本目录，无需手动设置「起始于」。如需在锁屏/未登录时也执行，可在任务计划程序中把「安全选项」改为「不管用户是否登录都要运行」并保存密码。
+> 脚本会自动定位项目根目录并读取配置，无需设置「起始于」。如需在锁屏/未登录时也执行，可把任务的「安全选项」改为「不管用户是否登录都要运行」并保存密码。
 
 ### 青龙面板
 

--- a/script/workbuddy/api.py
+++ b/script/workbuddy/api.py
@@ -146,11 +146,11 @@ class WorkBuddyAPI:
         except requests.RequestException as e:
             return {'success': False, 'error': f'请求 {path} 失败: {e}', 'error_type': 'network'}
 
-        # 401/403 视为令牌失效
-        if response.status_code in (401, 403):
+        # 仅 401 视为令牌失效；403 通常是网关拦截（如 UA 校验），保留响应体信息走通用分支
+        if response.status_code == 401:
             return {
                 'success': False,
-                'error': f'令牌已失效 (http={response.status_code})',
+                'error': '令牌已失效 (http=401)',
                 'error_type': 'token_expired',
             }
 
@@ -176,7 +176,7 @@ class WorkBuddyAPI:
         code = body.get('code', -1)
         if code != 0:
             error_type = 'business'
-            if code in (401, 403) or '登录' in str(message) or 'token' in str(message).lower():
+            if code == 401 or '登录' in str(message) or 'token' in str(message).lower():
                 error_type = 'token_expired'
             return {
                 'success': False,

--- a/script/workbuddy/import_accounts.py
+++ b/script/workbuddy/import_accounts.py
@@ -3,21 +3,22 @@
 """
 WorkBuddy账号导入工具
 
-将 cockpit-tools (https://github.com/jlcodes99/cockpit-tools) 管理的 WorkBuddy 账号
-批量导入到本项目的 config/token.json 中的 workbuddy 节点。
+将本机已有的 WorkBuddy 账号批量导入到本项目的 config/token.json 中的 workbuddy 节点。
 
 支持的导入来源：
-1. 自动探测本机 cockpit-tools 数据目录（默认行为）
-2. 指定 cockpit-tools 数据目录或 workbuddy_accounts 目录
-3. 指定单个账号 JSON 文件，或包含账号数组的 JSON 文件
+1. 官方 WorkBuddy 客户端（自动探测，读取当前登录账号，逻辑对齐 cockpit-tools 原版本机导入）
+2. cockpit-tools 数据目录（批量导入其管理的全部账号）
+3. 指定账号 JSON 文件，或包含账号数组的 JSON 文件
 
-账号存储兼容两种格式：
-- 明文：直接包含 access_token 字段
-- 加密：cockpit-tools 新版使用 AES-256-GCM 加密（字段 ciphertext/nonce），
-       本工具会用本机 secure-account-storage.key 自动解密
+官方客户端凭据存储（对齐 cockpit-tools 实现）：
+- 数据库：%APPDATA%/WorkBuddy/User/globalStorage/state.vscdb（macOS/Linux 对应各自目录）
+- 读取 ItemTable 中 secret://{"extensionId":"tencent-cloud.coding-copilot","key":"planning-genie.new.accessTokencn"}
+- Windows：Local State 的 os_crypt.encrypted_key 经 DPAPI 解出 AES 密钥，AES-256-GCM（v10 前缀）
+- macOS：Keychain "WorkBuddy Safe Storage" + PBKDF2-SHA1 派生密钥，AES-128-CBC（v10 前缀）
+- token 兼容 "uid+token" 拼接格式
 
 使用示例：
-    python import_accounts.py                      # 自动探测并导入
+    python import_accounts.py                      # 官方客户端 + cockpit-tools 自动探测导入
     python import_accounts.py --list               # 仅预览，不写入配置
     python import_accounts.py --path D:/xxx.json   # 从指定文件导入
     python import_accounts.py --path D:/xxx/dir    # 从指定目录导入
@@ -25,8 +26,11 @@ WorkBuddy账号导入工具
 
 import argparse
 import base64
+import hashlib
 import json
 import os
+import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -40,11 +44,272 @@ ACCOUNTS_DIR_NAME = "workbuddy_accounts"
 # 加密账号使用的本地密钥文件名
 KEY_FILE_NAME = "secure-account-storage.key"
 
+# 官方 WorkBuddy 客户端的 Secret Storage 标识（与 cockpit-tools 原版一致）
+OFFICIAL_EXTENSION_ID = 'tencent-cloud.coding-copilot'
+OFFICIAL_SECRET_KEY = 'planning-genie.new.accessTokencn'
+
 try:
     from Crypto.Cipher import AES
     HAS_CRYPTO = True
 except ImportError:
     HAS_CRYPTO = False
+
+# HAS_CRYPTO 为 False 时只提示一次，避免逐文件刷屏
+_crypto_warned = False
+
+
+def _warn_no_crypto() -> None:
+    """遇到加密账号但缺少 pycryptodome 时给出一次性安装提示"""
+    global _crypto_warned
+    if not _crypto_warned:
+        _crypto_warned = True
+        print("⚠️  检测到加密存储的账号，但缺少 pycryptodome，无法解密（pip install pycryptodome）")
+
+
+def find_official_client_db() -> Optional[Path]:
+    """
+    定位官方 WorkBuddy 客户端凭据数据库（对齐 cockpit-tools get_default_workbuddy_state_db_path）
+
+    Returns:
+        Optional[Path]: state.vscdb 路径，未找到返回 None
+    """
+    roots: List[Path] = []
+    if sys.platform == 'win32':
+        appdata = os.environ.get('APPDATA') or str(Path.home() / 'AppData' / 'Roaming')
+        roots.append(Path(appdata) / 'WorkBuddy')
+    elif sys.platform == 'darwin':
+        roots.append(Path.home() / 'Library' / 'Application Support' / 'WorkBuddy')
+    else:
+        xdg = os.environ.get('XDG_CONFIG_HOME') or str(Path.home() / '.config')
+        roots.append(Path(xdg) / 'WorkBuddy')
+
+    for root in roots:
+        db_path = root / 'User' / 'globalStorage' / 'state.vscdb'
+        if db_path.is_file():
+            return db_path
+    return None
+
+
+def _dpapi_decrypt(data: bytes) -> bytes:
+    """Windows DPAPI CryptUnprotectData（对齐 cockpit-tools dpapi_decrypt）"""
+    import ctypes
+
+    class _BLOB(ctypes.Structure):
+        _fields_ = [('cbData', ctypes.c_uint), ('pbData', ctypes.c_void_p)]
+
+    buf = ctypes.create_string_buffer(bytes(data), len(data))
+    src = _BLOB(len(data), ctypes.cast(buf, ctypes.c_void_p))
+    dst = _BLOB()
+    if not ctypes.windll.crypt32.CryptUnprotectData(
+            ctypes.byref(src), None, None, None, None, 0, ctypes.byref(dst)):
+        raise OSError('DPAPI CryptUnprotectData 调用失败')
+    try:
+        return ctypes.string_at(dst.pbData, dst.cbData)
+    finally:
+        if dst.pbData:
+            ctypes.windll.kernel32.LocalFree(ctypes.c_void_p(dst.pbData))
+
+
+def _decrypt_windows_v10(data_root: Path, encrypted: bytes) -> str:
+    """
+    Windows 平台解密：Local State 的 DPAPI 加密密钥 + AES-256-GCM
+    （对齐 cockpit-tools get_windows_encryption_key + decrypt_windows_gcm_v10）
+    """
+    if len(encrypted) < 31 or encrypted[:3] != b'v10':
+        raise ValueError('密文不是 Windows v10 格式')
+
+    local_state_path = data_root / 'Local State'
+    local_state = json.loads(local_state_path.read_text(encoding='utf-8'))
+    encrypted_key = base64.b64decode(local_state['os_crypt']['encrypted_key'])
+    if encrypted_key[:5] != b'DPAPI':
+        raise ValueError('encrypted_key 前缀不是 DPAPI')
+
+    key = _dpapi_decrypt(encrypted_key[5:])
+    cipher = AES.new(key, AES.MODE_GCM, nonce=encrypted[3:15])
+    plain = cipher.decrypt_and_verify(encrypted[15:-16], encrypted[-16:])
+    return plain.decode('utf-8')
+
+
+def _decrypt_macos_v10(data_root: Path, encrypted: bytes) -> str:
+    """
+    macOS 平台解密：Keychain 中的 WorkBuddy Safe Storage 密码 + PBKDF2-SHA1 派生密钥 + AES-128-CBC
+    （对齐 cockpit-tools get_macos_safe_storage_password + pbkdf2_sha1_key + decrypt_cbc_prefixed）
+    """
+    if encrypted[:3] != b'v10':
+        raise ValueError('密文不是 macOS v10 格式')
+
+    candidates = ['WorkBuddy', 'workbuddy', 'WorkBuddy Key', None, 'WorkBuddy Safe Storage']
+    for account in candidates:
+        cmd = ['security', 'find-generic-password', '-w', '-s', 'WorkBuddy Safe Storage']
+        if account:
+            cmd += ['-a', account]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0 or not result.stdout.strip():
+            continue
+        password = result.stdout.strip()
+        key = hashlib.pbkdf2_hmac('sha1', password.encode('utf-8'), b'saltysalt', 1003, dklen=16)
+        cipher = AES.new(key, AES.MODE_CBC, iv=b' ' * 16)
+        plain = cipher.decrypt(encrypted[3:])
+        pad_len = plain[-1]
+        if 1 <= pad_len <= 16 and plain[-pad_len:] == bytes([pad_len]) * pad_len:
+            return plain[:-pad_len].decode('utf-8')
+    raise OSError('未能从 Keychain 读取 WorkBuddy Safe Storage 密码')
+
+
+def read_official_client_secret(db_path: Path) -> Optional[str]:
+    """
+    从 state.vscdb 读取并解密 WorkBuddy Secret Storage 值
+    （对齐 cockpit-tools read_secret_storage_value_with_data_root_and_mode + decode_secret_storage_value）
+    """
+    item_key = f'secret://{{"extensionId":"{OFFICIAL_EXTENSION_ID}","key":"{OFFICIAL_SECRET_KEY}"}}'
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute('SELECT value FROM ItemTable WHERE key = ?', (item_key,)).fetchone()
+    finally:
+        conn.close()
+    if not row or not row[0]:
+        return None
+    raw = row[0]
+
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+    # Node Buffer JSON 形态：{"type":"Buffer","data":[...]}，取出密文字节后按平台解密
+    if isinstance(parsed, dict) and isinstance(parsed.get('data'), list):
+        encrypted = bytes(parsed['data'])
+        data_root = db_path.parent.parent.parent
+        if sys.platform == 'win32':
+            return _decrypt_windows_v10(data_root, encrypted)
+        if sys.platform == 'darwin':
+            return _decrypt_macos_v10(data_root, encrypted)
+        raise NotImplementedError(
+            'Linux 平台暂不支持解密官方客户端凭据，请改用 cockpit-tools 或手动导入')
+    if isinstance(parsed, str):
+        return parsed
+    return raw
+
+
+def _pick_local_token(value: Any) -> Optional[str]:
+    """宽松提取 access token（对齐 cockpit-tools parse_local_access_token）"""
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, list):
+        for item in value:
+            found = _pick_local_token(item)
+            if found:
+                return found
+        return None
+    if isinstance(value, dict):
+        for key in ('token', 'access_token', 'accessToken'):
+            v = value.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+        auth = value.get('auth')
+        if isinstance(auth, dict):
+            for key in ('accessToken', 'access_token'):
+                v = auth.get(key)
+                if isinstance(v, str) and v.strip():
+                    return v.strip()
+        for key in ('session', 'data'):
+            found = _pick_local_token(value.get(key))
+            if found:
+                return found
+    return None
+
+
+def account_from_official_secret(secret: str) -> Optional[Dict[str, Any]]:
+    """
+    从解密后的 secret 提取账号信息（对齐 cockpit-tools build_local_import_payload）
+
+    兼容 JSON（含 auth/account 对象）与纯 token 字符串两种形态，
+    token 兼容 "uid+token" 拼接格式。
+
+    Returns:
+        Optional[Dict[str, Any]]: convert_account 兼容的原始账号结构，解析失败返回 None
+    """
+    try:
+        parsed: Any = json.loads(secret)
+        if not isinstance(parsed, dict):
+            parsed = None
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+
+    raw_token = _pick_local_token(parsed) if parsed else None
+    if not raw_token:
+        raw_token = secret.strip() or None
+    if not raw_token:
+        return None
+
+    # 拆分 "uid+token" 拼接格式（对齐 extract_local_workbuddy_token_parts）
+    uid_from_token: Optional[str] = None
+    if '+' in raw_token:
+        prefix, _, suffix = raw_token.partition('+')
+        suffix = suffix.strip()
+        if not suffix:
+            return None
+        uid_from_token = prefix.strip() or None
+        raw_token = suffix
+
+    root = parsed or {}
+    account = root.get('account') if isinstance(root.get('account'), dict) else {}
+    auth = root.get('auth') if isinstance(root.get('auth'), dict) else {}
+
+    def pick(obj: Dict[str, Any], *keys: str) -> Optional[str]:
+        for key in keys:
+            v = obj.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+        return None
+
+    uid = pick(root, 'uid') or pick(account, 'uid', 'id') or uid_from_token
+    nickname = pick(root, 'nickname', 'name') or pick(account, 'nickname', 'label')
+    email = (pick(root, 'email') or pick(account, 'email') or pick(auth, 'email')
+             or nickname or uid or 'unknown')
+    enterprise_id = (pick(root, 'enterpriseId', 'enterprise_id')
+                     or pick(account, 'enterpriseId', 'enterprise_id'))
+    refresh_token = (pick(root, 'refreshToken', 'refresh_token')
+                     or pick(auth, 'refreshToken', 'refresh_token'))
+    domain = pick(root, 'domain') or pick(auth, 'domain')
+
+    raw: Dict[str, Any] = {
+        'nickname': nickname or email,
+        'email': email,
+        'access_token': raw_token,
+    }
+    if refresh_token:
+        raw['refresh_token'] = refresh_token
+    if uid:
+        raw['uid'] = uid
+    if enterprise_id:
+        raw['enterprise_id'] = enterprise_id
+    if domain:
+        raw['domain'] = domain
+    return raw
+
+
+def load_accounts_from_official_client(quiet: bool = False) -> List[Dict[str, Any]]:
+    """
+    从官方 WorkBuddy 客户端读取当前登录账号
+    （对齐 cockpit-tools import_payload_from_local，单账号）
+
+    Returns:
+        List[Dict[str, Any]]: 原始账号数据列表，未找到返回空列表
+    """
+    db_path = find_official_client_db()
+    if not db_path:
+        return []
+    try:
+        secret = read_official_client_secret(db_path)
+    except Exception as e:
+        if not quiet:
+            print(f"⚠️  读取官方客户端凭据失败: {e}")
+        return []
+    if not secret:
+        return []
+    account = account_from_official_secret(secret)
+    return [account] if account else []
 
 
 def find_cockpit_data_dirs() -> List[Path]:
@@ -142,6 +407,7 @@ def decrypt_record(enc: Dict[str, Any], key: bytes) -> Optional[Dict[str, Any]]:
         Optional[Dict[str, Any]]: 解密后的明文账号数据，失败返回 None
     """
     if not HAS_CRYPTO:
+        _warn_no_crypto()
         return None
     try:
         nonce = base64.b64decode(enc['nonce'])
@@ -155,7 +421,7 @@ def decrypt_record(enc: Dict[str, Any], key: bytes) -> Optional[Dict[str, Any]]:
         return None
 
 
-def load_accounts_from_dir(directory: Path) -> List[Dict[str, Any]]:
+def load_accounts_from_dir(directory: Path, quiet: bool = False) -> List[Dict[str, Any]]:
     """
     从目录中读取 WorkBuddy 账号详情
 
@@ -164,6 +430,7 @@ def load_accounts_from_dir(directory: Path) -> List[Dict[str, Any]]:
 
     Args:
         directory (Path): 目录路径
+        quiet (bool): True 时不输出警告信息
 
     Returns:
         List[Dict[str, Any]]: 原始账号数据列表
@@ -181,7 +448,8 @@ def load_accounts_from_dir(directory: Path) -> List[Dict[str, Any]]:
         try:
             key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
         except Exception as e:
-            print(f"⚠️  读取密钥失败: {e}")
+            if not quiet:
+                print(f"⚠️  读取密钥失败: {e}")
 
     accounts: List[Dict[str, Any]] = []
     for json_file in sorted(accounts_dir.glob('*.json')):
@@ -191,11 +459,16 @@ def load_accounts_from_dir(directory: Path) -> List[Dict[str, Any]]:
             with open(json_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
         except (json.JSONDecodeError, OSError) as e:
-            print(f"⚠️  跳过无法解析的文件 {json_file.name}: {e}")
+            if not quiet:
+                print(f"⚠️  跳过无法解析的文件 {json_file.name}: {e}")
             continue
 
         # 加密格式：含 ciphertext 字段
-        if isinstance(data, dict) and data.get('ciphertext') and key:
+        if isinstance(data, dict) and data.get('ciphertext'):
+            if not key:
+                if not quiet:
+                    print(f"⚠️  跳过加密账号 {json_file.name}: 未找到解密密钥 {KEY_FILE_NAME}")
+                continue
             data = decrypt_record(data, key)
             if not data:
                 continue
@@ -228,10 +501,13 @@ def load_accounts_from_file(file_path: Path) -> List[Dict[str, Any]]:
         if data.get('ciphertext'):
             key_path = find_secure_key(file_path.parent)
             if key_path:
-                key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
-                dec = decrypt_record(data, key)
-                if dec:
-                    data = dec
+                try:
+                    key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
+                    dec = decrypt_record(data, key)
+                    if dec:
+                        data = dec
+                except Exception as e:
+                    print(f"⚠️  解密文件 {file_path.name} 失败: {e}")
         if isinstance(data.get('accounts'), list):
             data = data['accounts']
         else:
@@ -337,20 +613,31 @@ def merge_into_config(new_accounts: List[Dict[str, Any]], config_path: Path) -> 
     return {'added': added, 'updated': updated}
 
 
-def collect_accounts() -> List[Dict[str, Any]]:
+def collect_accounts(quiet: bool = False) -> List[Dict[str, Any]]:
     """
-    自动探测 cockpit-tools 数据目录并采集账号（已转换、去重）
+    自动探测本机账号来源并采集账号（已转换、去重）
+
+    来源优先级：官方 WorkBuddy 客户端（当前登录账号）→ cockpit-tools 数据目录（全部账号）
+
+    Args:
+        quiet (bool): True 时不输出来源提示
 
     Returns:
         List[Dict[str, Any]]: 转换后的账号配置列表，无可用来源时返回空列表
     """
-    candidates = find_cockpit_data_dirs()
-    if not candidates:
-        return []
-
+    log = (lambda *a, **k: None) if quiet else print
     raw_accounts: List[Dict[str, Any]] = []
-    for candidate in candidates:
-        raw_accounts.extend(load_accounts_from_dir(candidate))
+
+    official = load_accounts_from_official_client(quiet=quiet)
+    if official:
+        log("📂 来源: 官方 WorkBuddy 客户端 (发现 1 个账号)")
+        raw_accounts.extend(official)
+
+    for candidate in find_cockpit_data_dirs():
+        found = load_accounts_from_dir(candidate, quiet=quiet)
+        if found:
+            log(f"📂 来源: {candidate} (发现 {len(found)} 个账号)")
+            raw_accounts.extend(found)
 
     accounts: List[Dict[str, Any]] = []
     seen = set()
@@ -385,7 +672,7 @@ def sync_accounts(config_path: Optional[Path] = None, quiet: bool = False) -> Op
     """
     log = (lambda *a, **k: None) if quiet else print
     try:
-        accounts = collect_accounts()
+        accounts = collect_accounts(quiet=quiet)
         if not accounts:
             return None
         stats = merge_into_config(accounts, config_path or CONFIG_PATH)
@@ -432,19 +719,7 @@ def main():
                 seen.add(identity)
             accounts.append(converted)
     else:
-        print("🔍 正在自动探测 cockpit-tools 数据目录...")
-        candidates = find_cockpit_data_dirs()
-
-        if not candidates:
-            print("❌ 未找到 cockpit-tools 数据目录")
-            print("   请使用 --path 手动指定账号目录或导出的 JSON 文件，例如：")
-            print("   python import_accounts.py --path \"C:/Users/你的用户名/.antigravity_cockpit\"")
-            sys.exit(1)
-
-        for candidate in candidates:
-            found = load_accounts_from_dir(candidate)
-            if found:
-                print(f"📂 来源: {candidate} (发现 {len(found)} 个账号)")
+        print("🔍 正在自动探测官方 WorkBuddy 客户端与 cockpit-tools 数据目录...")
         accounts = collect_accounts()
 
     if not accounts:

--- a/script/workbuddy/main.py
+++ b/script/workbuddy/main.py
@@ -133,11 +133,13 @@ class WorkBuddyTasks:
             if api.domain:
                 accounts[account_index]['domain'] = api.domain
 
-            with open(self.config_path, 'w', encoding='utf-8') as f:
+            # 原子写入：先写临时文件再替换，避免进程中断导致配置文件截断损坏
+            tmp_path = self.config_path.with_suffix('.json.tmp')
+            with open(tmp_path, 'w', encoding='utf-8') as f:
                 json.dump(config_data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp_path, self.config_path)
 
             self.logger.info("💾 新令牌已写回配置文件")
-
         except Exception as e:
             self.logger.warning(f"⚠️ 回写令牌失败: {e}")
 
@@ -191,8 +193,8 @@ class WorkBuddyTasks:
             if not status['success']:
                 error_msg = status.get('error', '查询签到状态失败')
                 if status.get('error_type') == 'token_expired':
-                    result['message'] = '令牌已过期，请重新导入账号'
-                    self.logger.error(f"❌ {account_name} 令牌已过期，请重新导入账号")
+                    result['message'] = f'{error_msg}，请重新导入账号'
+                    self.logger.error(f"❌ {account_name} {result['message']}")
                 else:
                     result['message'] = error_msg
                     self.logger.error(f"❌ {account_name} {error_msg}")


### PR DESCRIPTION
## 背景

#46 合并时只包含初版 commit（`69eca64`），后续补充的官方客户端导入功能与 Copilot review 修复推送在合并之后，未能进入上游。本 PR 补齐这部分内容。

## 内容 1：官方客户端导入（对齐 cockpit-tools 原版）

`import_accounts.py` 新增从官方 WorkBuddy 客户端读取当前登录账号的能力，实现完全对齐 cockpit-tools 的 `import_payload_from_local`：

- 数据库：`%APPDATA%/WorkBuddy/User/globalStorage/state.vscdb`（macOS/Linux 对应各自目录）
- 读取 `ItemTable` 中 `secret://{"extensionId":"tencent-cloud.coding-copilot","key":"planning-genie.new.accessTokencn"}`
- Windows：`Local State` 的 `os_crypt.encrypted_key` 经 DPAPI 解出 AES-256 密钥，AES-256-GCM（v10 前缀）
- macOS：Keychain `WorkBuddy Safe Storage` + PBKDF2-SHA1(1003, saltysalt) 派生密钥，AES-128-CBC
- token 兼容 `uid+token` 拼接格式，与 cockpit-tools 来源按 uid 自动去重合并

这让**不使用 cockpit-tools 的用户**也能一键导入账号，无需抓包。

## 内容 2：Copilot review 6 条意见修复（逐条回复见 #46 评论）

1. `api.py`：仅 401 判定 `token_expired`，403 保留网关错误详情不再误判
2. `import_accounts.py`：缺少 pycryptodome / 解密密钥时输出一次性明确提示，不再静默失败
3. `main.py`：令牌回写改为临时文件 + `os.replace()` 原子写入
4. `main.py`：`token_expired` 时保留 API 层具体错误原因，仅追加操作建议
5. `template_token.json`：`workbuddy.domain` 模板置空
6. README：依赖补充 `pycryptodome`；另修正了引用 run.bat 的定时任务说明（PR 不含 bat）

## 测试

- Windows 11 实测：官方客户端凭据解密导入成功，与 cockpit-tools 来源按 uid 合并共 9 个账号
- `python import_accounts.py --list` 预览、静默同步、签到链路全部实测通过