### PR TITLE
新增 Trae CN / Agent Router 签到模块，优化 WorkBuddy 同步

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 config/token.json
 config/notification.json
 config/*.secret.json
+
+# IDE internal docs
+.trae/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 | 📝 WPS Office  | `script/wps/main.py` | ✅ 可用 | 支持任务中心和天天领福利双页面任务 |
 | 💰 什么值得买      | `script/smzdm/sign_daily_task/main.py` | ✅ 可用 | 支持每日签到和众测任务         |
 | 🤖 WorkBuddy    | `script/workbuddy/main.py` | ✅ 可用 | 支持每日签到、令牌自动续期与多账号管理 |
+| 🐅 Trae CN       | `script/trae/main.py` | ✅ 可用 | 支持积分计费模式每日签到与多账号管理 |
+| 🚀 Agent Router  | `script/agentrouter/main.py` | ✅ 可用 | 支持 OAuth 登录即签到、余额查询 |
 
 ### 状态说明
 
@@ -60,9 +62,13 @@ WorkBuddy（CodeBuddy）每日签到脚本，接口实现参考 [cockpit-tools](
 - `script/workbuddy/import_accounts.py`：账号导入工具，一键导入官方 WorkBuddy 客户端当前登录账号（自动解密凭据库），也支持从 cockpit-tools 批量导入或指定 JSON 文件导入
 - `script/workbuddy/main.py`：统一入口，多账号签到编排、令牌自动续期与结果推送
 
-支持每日签到、连签奖励、多账号管理、令牌自动续期（access_token 60 天 / refresh_token 90 天，自动轮换续期），签到前自动同步本机官方客户端 / cockpit-tools 的最新令牌。详见 [script/workbuddy/README.md](script/workbuddy/README.md)。
+支持每日签到、连签奖励、多账号管理、令牌自动续期（access_token 60 天 / refresh_token 90 天，自动轮换续期）。详见 [script/workbuddy/README.md](script/workbuddy/README.md)。
 
 ## 📝 更新日志
+
+### 2026-09-12
+- ✨ 新增 Trae CN、Agent Router 自动签到模块，详见各脚本子目录 README
+- 🧹 精简账号配置并移除签到前自动同步逻辑，详见 `script/trae/README.md`、`script/workbuddy/README.md`
 
 ### 2026-09-06
 - ✨ **新增 WorkBuddy(CodeBuddy) 自动签到模块**:

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -192,5 +192,13 @@
         "domain": ""
       }
     ]
+  },
+  "trae": {
+    "accounts": [
+      {
+        "account_name": "主号",
+        "session": "浏览器 X-Cloudide-Session 的完整值"
+      }
+    ]
   }
 }

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -197,8 +197,7 @@
     "accounts": [
       {
         "account_name": "主号",
-        "session": "浏览器 X-Cloudide-Session 的完整值",
-        "refresh_cookies": "sessionid=xxx; sid_tt=xxx; uid_tt=xxx"
+        "refresh_cookies": "sessionid=浏览器 Cookie 的 sessionid 值"
       }
     ]
   }

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -197,7 +197,8 @@
     "accounts": [
       {
         "account_name": "主号",
-        "session": "浏览器 X-Cloudide-Session 的完整值"
+        "session": "浏览器 X-Cloudide-Session 的完整值",
+        "refresh_cookies": "sessionid=xxx; sid_tt=xxx; uid_tt=xxx"
       }
     ]
   }

--- a/config/template_token.json
+++ b/config/template_token.json
@@ -197,7 +197,7 @@
     "accounts": [
       {
         "account_name": "主号",
-        "refresh_cookies": "sessionid=浏览器 Cookie 的 sessionid 值"
+        "sessionid": "浏览器 Cookie 的 sessionid 值"
       }
     ]
   }

--- a/script/agentrouter/README.md
+++ b/script/agentrouter/README.md
@@ -1,0 +1,111 @@
+# Agent Router 每日签到
+
+[Agent Router](https://ps.air-outer.com/console)（备用域名，原域名 `agentrouter.org` 境内不通）
+是基于 New API 的大模型 API 网关，每日签到送 $25 额度。
+
+## 签到原理
+
+站点**没有独立签到入口**，额度在**登录时**发放（官方 FAQ：「签到领 $25 额度」需要退出后
+重新登录才会到账）。因此脚本每天完整重走一次 GitHub OAuth 登录，登录成功即签到成功。
+
+```
+站点 /api/oauth/state          取签名 state（同时下发 session cookie）
+        ↓
+GitHub /login/oauth/authorize  用 GitHub 登录态换 code
+        ↓
+站点 /api/oauth/github         带 code + state 登录 → 额度到账
+```
+
+GitHub OAuth App 注册的回调域名是 `agentrouter.org`（境内不可达），脚本只从其跳转地址中
+提取 `code`，从不访问该域名，随后统一用配置中的 `base_url`（默认 `https://ps.air-outer.com`）
+发起登录请求，等价于把回调域名替换成备用域名。
+
+签到结果由登录响应给出：服务端在登录流程中完成签发，响应 `data.checked_in` 为 `true`
+即「今日已签到」（前端据此弹出「签到成功，新增额度已到账」）。所以**没有、也不需要独立
+签到接口**，重登即签到。
+
+站点未开放账号密码登录（账号为 GitHub 注册、无独立密码），GitHub OAuth 是唯一登录路径。
+
+## 配置
+
+在 `config/token.json` 中新增 `agentrouter` 节点：
+
+```json
+{
+  "agentrouter": {
+    "accounts": [
+      {
+        "account_name": "erma0",
+        "github_cookies": "user_session=xxx; __Host-user_session_same_site=xxx; logged_in=yes",
+        "base_url": "https://ps.air-outer.com"
+      }
+    ]
+  }
+}
+```
+
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `account_name` | 否 | 备注名，仅用于日志和通知展示 |
+| `github_cookies` | 二选一 | github.com 的完整 Cookie 串（推荐）或 cookie 字典 |
+| `github_session` | 二选一 | 仅 `user_session` 的值，脚本自动补齐 `logged_in` 等标记 |
+| `user_id` | 否 | 站点用户 ID，用于 `new-api-user` 请求头；不填则签到照常，只是查不到余额 |
+| `base_url` | 否 | 站点地址，默认 `https://ps.air-outer.com` |
+| `proxy` | 否 | 访问 GitHub 用的代理，如 `http://127.0.0.1:7890`；留空沿用环境变量 |
+| `verify` | 否 | TLS 校验，留空自动合并系统根证书；可填证书路径，或 `false` 跳过校验 |
+
+> `user_id` 获取：登录后 F12 → 网络（Network）→ 任一 `/api/` 请求 → 请求头里的
+> `new-api-user`。站点用它识别用户，缺失时接口会返回「未提供 New-Api-User」。
+> 登录响应若带回用户 ID，脚本会自动补上，无需手动填。
+
+### 获取 GitHub 登录态
+
+登录态只用于换取 OAuth 授权码，本站不读取任何浏览器数据，需要手动复制一次：
+
+1. 浏览器打开 <https://github.com> 并确保已登录
+2. F12 打开开发者工具 → 应用程序（Application）→ Cookie → `https://github.com`
+3. 找到 `user_session`，复制其值；更稳妥的做法是从网络（Network）面板任一 github.com
+   请求的 `Cookie` 请求头里整串复制
+
+`user_session` 有效期较长（通常一年），填一次即可长期自动运行；失效时日志会提示
+「GitHub 登录态无效或已过期」，重新复制即可。
+
+> 首次运行若该 GitHub 账号尚未授权过此应用，脚本会自动提交授权同意表单，无需手动点击。
+
+## 运行
+
+```bash
+python script/agentrouter/main.py            # 执行签到
+python script/agentrouter/main.py --dry-run   # 仅校验配置
+```
+
+定时任务建议每天一次，cron 示例：
+
+```
+20 9 * * * cd /path/to/ZaiZaiCat-Checkin && python script/agentrouter/main.py
+```
+
+## 常见问题
+
+**证书验证失败（`unable to get local issuer certificate`）**
+
+用了 Watt Toolkit / SteamTools 之类的 GitHub 加速器时，github.com 的流量走本地 TLS
+中间人，根证书只装在 Windows 系统证书库、不在 Python 的 certifi 里。脚本已自动合并
+`certifi + 系统 ROOT 证书` 生成 CA bundle，正常情况下无需处理；若仍报错，可把 `verify`
+配成对应根证书的路径，或临时设为 `false`（不推荐）。
+
+**提示 GitHub 登录态无效或已过期**
+
+浏览器重新登录 github.com，按上文步骤重新复制 Cookie 到 `github_cookies`。
+
+## 说明
+
+- 站点把签到挂在登录流程里，登录成功即视为签到成功，脚本会同时输出账号当前余额
+- 站点对非白名单路由统一返回「无权进行此操作，权限不足」，实测 `/api/user/sign_in`、
+  `/checkin`、`/check_in`、`/daily_checkin` 等均不可用，即**只能通过重新登录领取额度**
+- 签到结果按站点原版逻辑判断：登录响应 `data.checked_in` 为 `true` 时输出
+  「签到成功，新增额度已到账」（与前端 toast 一致）
+- `checked_in` 表示「**今日已签到**」状态（实测同一天重复登录它始终为 `true`，并非
+  「本次新签到」）。额度实际每天只发放一次，站点日志里每天只新增一条
+  「每日签到成功，增加额度 ＄25.000000 额度」记录，重复登录不会重复到账
+- 多账号依次处理，账号之间间隔 5 秒

--- a/script/agentrouter/api.py
+++ b/script/agentrouter/api.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Agent Router（ps.air-outer.com，原域名 agentrouter.org）签到 API 模块
+
+站点基于 New API，签到规则特殊：控制台没有「签到」按钮，额度在**登录流程中**由服务端
+发放（官方 FAQ：「签到领 $25 额度」需要退出后重新登录才会到账）。因此本模块的签到动作
+就是完整重走一次 GitHub OAuth 登录，签到结果看登录响应的 `checked_in` 字段。
+
+登录链路（复刻前端 /assets/index-*.js 的实现）：
+    1. GET {base}/api/oauth/state
+       返回签名 state，同时下发 session cookie（服务端校验 state 依赖该 cookie）
+    2. GET github.com/login/oauth/authorize?client_id=&state=&scope=user:email
+       携带 github.com 登录态（由配置提供）后 302 到回调地址并附带 code。
+       回调域名由 GitHub OAuth App 注册信息决定，通常是 https://agentrouter.org
+       （境内不可达），脚本只从 Location 中取 code、从不访问该域名，随后统一用
+       base_url 发起回调请求，等价于把回调域名替换为 ps.air-outer.com。
+       若该 App 尚未授权，GitHub 会返回授权页面，脚本自动提交同意表单完成首次授权。
+    3. GET {base}/api/oauth/github?code=&state=&mode=login
+       登录成功即完成签到，响应 data 为用户对象，其中 checked_in 为签到标记
+"""
+
+import base64
+import html
+import logging
+import re
+import ssl
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
+
+import certifi
+import requests
+
+logger = logging.getLogger(__name__)
+
+# 备用域名（原域名 agentrouter.org 境内不通，默认走备用域名）
+DEFAULT_BASE_URL = 'https://ps.air-outer.com'
+# /api/status 会下发 github_client_id，取不到时的兜底值
+FALLBACK_CLIENT_ID = 'Ov23lidtiR4LeVZvVRNL'
+GITHUB_HOST = 'https://github.com'
+GITHUB_COOKIE_DOMAIN = '.github.com'
+
+DEFAULT_USER_AGENT = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+)
+
+# 换算额度为美元的默认值（站点 /api/status 的 quota_per_unit）
+DEFAULT_QUOTA_PER_UNIT = 500000
+
+
+def parse_cookie_string(cookie_str: str) -> Dict[str, str]:
+    """
+    解析 Cookie 请求头字符串为字典
+
+    Args:
+        cookie_str (str): "name=value; name2=value2" 形式的 Cookie 串
+
+    Returns:
+        Dict[str, str]: cookie 名值对
+    """
+    cookies: Dict[str, str] = {}
+    for part in (cookie_str or '').split(';'):
+        part = part.strip()
+        if not part or '=' not in part:
+            continue
+        name, value = part.split('=', 1)
+        cookies[name.strip()] = value.strip()
+    return cookies
+
+
+def build_github_cookies(github_cookies: Any = None, github_session: str = '') -> Dict[str, str]:
+    """
+    构造请求 github.com 使用的 cookie 字典
+
+    两种配置形式，按优先级：
+    1. github_cookies: 完整 Cookie 串或 dict（推荐，直接复制浏览器请求头即可）
+    2. github_session: 仅 user_session 的值（脚本补齐 logged_in 标记）
+
+    Args:
+        github_cookies (Any): Cookie 字符串或字典
+        github_session (str): github.com 的 user_session cookie 值
+
+    Returns:
+        Dict[str, str]: cookie 名值对
+    """
+    if isinstance(github_cookies, dict):
+        cookies = dict(github_cookies)
+    elif github_cookies:
+        cookies = parse_cookie_string(str(github_cookies))
+    else:
+        cookies = {}
+
+    session_value = (github_session or '').strip()
+    if session_value and 'user_session' not in cookies:
+        cookies['user_session'] = session_value
+        # GitHub 校验登录态时会同时参考这两个标记
+        cookies.setdefault('logged_in', 'yes')
+        cookies.setdefault('__Host-user_session_same_site', session_value)
+
+    return cookies
+
+
+def _unescape(text: str) -> str:
+    return html.unescape(text or '')
+
+
+@lru_cache(maxsize=1)
+def build_ca_bundle() -> Optional[str]:
+    """
+    合并 certifi 与 Windows 系统根证书，返回 PEM 文件路径
+
+    本机常见的 GitHub 加速器（SteamTools / Watt Toolkit 等）会对 github.com 做本地
+    TLS 中间人，其根证书只装在系统证书库中、不在 certifi 里，直接请求会报
+    「certificate verify failed: unable to get local issuer certificate」。
+    合并两者后 requests 才能正常校验。非 Windows 或导出失败时返回 None（沿用 certifi）。
+    """
+    parts = []
+    try:
+        parts.append(Path(certifi.where()).read_text(encoding='ascii'))
+    except Exception as exc:
+        logger.debug(f'读取 certifi 证书失败: {exc}')
+
+    try:
+        for der, encoding, _ in ssl.enum_certificates('ROOT'):
+            if encoding != 'x509_asn':
+                continue
+            encoded = base64.b64encode(der).decode('ascii')
+            body = '\n'.join(encoded[i:i + 64] for i in range(0, len(encoded), 64))
+            parts.append(f'-----BEGIN CERTIFICATE-----\n{body}\n-----END CERTIFICATE-----\n')
+    except Exception as exc:
+        logger.debug(f'导出系统根证书失败: {exc}')
+
+    if not parts:
+        return None
+
+    try:
+        path = Path(tempfile.gettempdir()) / 'agentrouter_ca_bundle.pem'
+        path.write_text('\n'.join(parts), encoding='ascii')
+        return str(path)
+    except Exception as exc:
+        logger.debug(f'写入 CA 合并文件失败: {exc}')
+        return None
+
+
+class AgentRouterAPI:
+    """Agent Router 登录签到 API 类"""
+
+    def __init__(self,
+                 base_url: str = '',
+                 github_cookies: Any = None,
+                 github_session: str = '',
+                 user_id: str = '',
+                 proxy: str = '',
+                 verify: Any = None,
+                 timeout: int = 30):
+        """
+        Args:
+            base_url (str): 站点地址，默认 https://ps.air-outer.com
+            github_cookies (Any): github.com 登录态，Cookie 串或字典
+            github_session (str): github.com 的 user_session 值（github_cookies 缺失时使用）
+            user_id (str): 站点用户 ID，用于 new-api-user 请求头（查余额必需）
+            proxy (str): 代理地址，如 http://127.0.0.1:7890；留空则沿用环境变量
+            verify (Any): TLS 校验，留空自动合并系统根证书；可填证书路径或 False
+            timeout (int): 请求超时时间（秒）
+        """
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip('/')
+        self.github_cookies = build_github_cookies(github_cookies, github_session)
+        self.user_id = str(user_id or '').strip()
+        self.timeout = timeout
+        self.verify = verify
+        self.proxies = {'http': proxy, 'https': proxy} if proxy else None
+        self._client_id: Optional[str] = None
+        self._quota_per_unit = DEFAULT_QUOTA_PER_UNIT
+
+    # ------------------------------------------------------------------ 基础请求
+
+    def _prepare(self, session: requests.Session) -> requests.Session:
+        """统一设置 TLS 校验与代理"""
+        if self.verify is not None:
+            session.verify = self.verify
+        else:
+            ca_bundle = build_ca_bundle()
+            if ca_bundle:
+                session.verify = ca_bundle
+        if self.proxies:
+            session.proxies.update(self.proxies)
+        return session
+
+    def _new_session(self) -> requests.Session:
+        session = requests.Session()
+        session.headers.update({
+            'User-Agent': DEFAULT_USER_AGENT,
+            'Accept': 'application/json, text/plain, */*',
+        })
+        # 站点用 new-api-user 请求头识别用户，缺它会返回「未提供 New-Api-User」
+        if self.user_id:
+            session.headers['new-api-user'] = self.user_id
+        return self._prepare(session)
+
+    @staticmethod
+    def _json_of(response: requests.Response) -> Dict[str, Any]:
+        try:
+            body = response.json()
+            return body if isinstance(body, dict) else {}
+        except ValueError:
+            return {}
+
+    @staticmethod
+    def _extract_user_id(data: Any) -> Optional[str]:
+        """从登录响应的用户对象中提取用户 ID"""
+        if isinstance(data, dict):
+            for key in ('id', 'user_id', 'uid'):
+                if data.get(key):
+                    return str(data[key])
+        return None
+
+    # ------------------------------------------------------------------ 站点信息
+
+    def get_status(self) -> Dict[str, Any]:
+        """获取站点公开配置（含 github_client_id、额度换算比例）"""
+        try:
+            resp = self._new_session().get(f'{self.base_url}/api/status', timeout=self.timeout)
+            body = self._json_of(resp)
+            data = body.get('data') or {}
+            if data.get('github_client_id'):
+                self._client_id = data['github_client_id']
+            quota_per_unit = data.get('quota_per_unit')
+            if isinstance(quota_per_unit, (int, float)) and quota_per_unit > 0:
+                self._quota_per_unit = quota_per_unit
+            return {'success': bool(body.get('success')), 'data': data}
+        except Exception as exc:
+            logger.warning(f'获取站点状态失败: {exc}')
+            return {'success': False, 'data': {}}
+
+    def get_github_client_id(self) -> str:
+        """获取 GitHub OAuth client_id，失败时回退到已知值"""
+        if not self._client_id:
+            self.get_status()
+        return self._client_id or FALLBACK_CLIENT_ID
+
+    # ------------------------------------------------------------------ OAuth 登录
+
+    def fetch_oauth_state(self, session: requests.Session) -> str:
+        """
+        获取登录用 state（服务端会把它写入本次会话）
+
+        Returns:
+            str: 签名 state
+
+        Raises:
+            RuntimeError: 接口未返回 state
+        """
+        resp = session.get(f'{self.base_url}/api/oauth/state', timeout=self.timeout)
+        body = self._json_of(resp)
+        state = body.get('data')
+        if not body.get('success') or not state:
+            raise RuntimeError(f'获取 oauth state 失败: {body.get("message") or resp.text[:200]}')
+        return str(state)
+
+    def _github_session(self) -> requests.Session:
+        session = requests.Session()
+        session.headers.update({
+            'User-Agent': DEFAULT_USER_AGENT,
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        })
+        for name, value in self.github_cookies.items():
+            session.cookies.set(name, value, domain=GITHUB_COOKIE_DOMAIN, path='/')
+        return self._prepare(session)
+
+    @staticmethod
+    def _extract_code(response: requests.Response) -> Optional[str]:
+        """从 GitHub 的 302 Location 中提取授权码 code"""
+        location = response.headers.get('Location') or ''
+        if not location or 'code=' not in location:
+            return None
+        # 跳回 github.com/login 说明登录态无效
+        if location.startswith(f'{GITHUB_HOST}/login'):
+            return None
+        return parse_qs(urlparse(location).query).get('code', [None])[0]
+
+    def _approve_authorize(self, github: requests.Session, page_html: str,
+                           authorize_url: str) -> Optional[str]:
+        """
+        首次授权时自动提交 GitHub 的「Authorize」同意表单
+
+        Args:
+            github (requests.Session): 带 GitHub 登录态的会话
+            page_html (str): 授权页面 HTML
+            authorize_url (str): 授权页地址，用于 Referer
+
+        Returns:
+            Optional[str]: 授权码 code，失败返回 None
+        """
+        action_match = re.search(r'<form[^>]+action="([^"]+)"', page_html)
+        if not action_match:
+            return None
+
+        form_action = _unescape(action_match.group(1))
+        if not form_action.startswith('http'):
+            form_action = GITHUB_HOST + form_action
+
+        payload: Dict[str, str] = {}
+        for tag in re.findall(r'<input[^>]*>', page_html):
+            if 'type="hidden"' not in tag:
+                continue
+            name_match = re.search(r'name="([^"]+)"', tag)
+            value_match = re.search(r'value="([^"]*)"', tag)
+            if name_match:
+                payload[name_match.group(1)] = _unescape(value_match.group(1)) if value_match else ''
+        if not payload:
+            return None
+
+        # 同意按钮：name="authorize" value="1"
+        payload['authorize'] = '1'
+        resp = github.post(form_action, data=payload, timeout=self.timeout,
+                           allow_redirects=False, headers={'Referer': authorize_url})
+        if resp.status_code not in (301, 302, 303):
+            logger.debug(f'提交授权表单后状态码异常: {resp.status_code}')
+        return self._extract_code(resp)
+
+    def authorize_github(self, state: str, client_id: str = '') -> Tuple[Optional[str], str]:
+        """
+        用 GitHub 登录态换取授权码
+
+        Args:
+            state (str): /api/oauth/state 下发的 state
+            client_id (str): GitHub OAuth client_id，留空则从站点状态接口获取
+
+        Returns:
+            Tuple[Optional[str], str]: (授权码 code, 方式说明)
+        """
+        client_id = client_id or self.get_github_client_id()
+        github = self._github_session()
+        params = {'client_id': client_id, 'state': state, 'scope': 'user:email'}
+        authorize_url = f'{GITHUB_HOST}/login/oauth/authorize'
+
+        resp = github.get(authorize_url, params=params, timeout=self.timeout, allow_redirects=False)
+        logger.debug(f'GitHub 授权响应: {resp.status_code} -> {resp.headers.get("Location", "")[:120]}')
+
+        code = self._extract_code(resp)
+        if code:
+            return code, '已授权应用，静默换取授权码'
+
+        if resp.status_code in (301, 302, 303):
+            location = resp.headers.get('Location') or ''
+            if location.startswith(f'{GITHUB_HOST}/login'):
+                raise RuntimeError(
+                    'GitHub 登录态无效或已过期，请更新配置中的 github_cookies / github_session')
+            raise RuntimeError(f'GitHub 授权未返回 code，跳转地址: {location[:200]}')
+
+        # 200：首次授权需要确认，自动提交同意表单
+        code = self._approve_authorize(github, resp.text, resp.url)
+        if code:
+            return code, '首次授权，已自动提交同意表单'
+
+        if '/login' in resp.url or 'Sign in to GitHub' in resp.text:
+            raise RuntimeError(
+                'GitHub 登录态无效或已过期，请更新配置中的 github_cookies / github_session')
+        raise RuntimeError(
+            '未能从 GitHub 获取授权码，请在浏览器中手动授权一次该应用后重试，'
+            f'或检查账号是否开启了额外验证。授权地址: {resp.url[:200]}')
+
+    def login_with_code(self, session: requests.Session, code: str, state: str) -> Dict[str, Any]:
+        """
+        用授权码完成登录（服务端在此完成签到）
+
+        Returns:
+            Dict[str, Any]: 含 success/message/data 的登录结果
+        """
+        resp = session.get(f'{self.base_url}/api/oauth/github',
+                           params={'code': code, 'state': state, 'mode': 'login'},
+                           timeout=self.timeout)
+        body = self._json_of(resp)
+        message = str(body.get('message') or '')
+        if not body.get('success'):
+            return {'success': False, 'error': message or f'登录失败（HTTP {resp.status_code}）'}
+        return {'success': True, 'message': message, 'data': body.get('data')}
+
+    def login_by_github(self) -> Dict[str, Any]:
+        """
+        完整走一遍 GitHub OAuth 登录（即签到动作）
+
+        Returns:
+            Dict[str, Any]: 含 success/session/mode/user/checked_in 的结果；
+                失败时含 error/error_type
+        """
+        if not self.github_cookies:
+            return {
+                'success': False,
+                'error': '缺少 GitHub 登录态，请在配置中填写 github_cookies 或 github_session',
+                'error_type': 'missing_credential',
+            }
+
+        session = self._new_session()
+        try:
+            state = self.fetch_oauth_state(session)
+            code, via = self.authorize_github(state)
+            if not code:
+                return {'success': False, 'error': 'GitHub 未返回授权码', 'error_type': 'auth_failed'}
+            result = self.login_with_code(session, code, state)
+        except Exception as exc:
+            return {'success': False, 'error': str(exc), 'error_type': 'auth_failed'}
+
+        if not result['success']:
+            result['error_type'] = 'login_failed'
+            return result
+
+        return self._finalize_login(session, result.get('data'), f'GitHub OAuth 登录（{via}）')
+
+    def _finalize_login(self, session: requests.Session, data: Any, mode: str) -> Dict[str, Any]:
+        """
+        收尾登录结果：补 new-api-user 头、提取用户信息与签到标记
+
+        服务端在登录流程中完成签到，响应的 data 即用户对象，`checked_in` 表示
+        本次登录是否达成签到（前端据此弹出「签到成功，新增额度已到账」）。
+        """
+        user = data if isinstance(data, dict) else {}
+        user_id = self._extract_user_id(data)
+        if user_id:
+            self.user_id = user_id
+            session.headers['new-api-user'] = user_id
+
+        return {
+            'success': True,
+            'session': session,
+            'mode': mode,
+            'user': user,
+            'user_id': user_id,
+            'checked_in': bool(user.get('checked_in')),
+        }
+
+    # ------------------------------------------------------------------ 账号信息
+
+    def get_user_self(self, session: requests.Session) -> Dict[str, Any]:
+        """
+        查询当前登录用户信息（含额度）
+
+        Returns:
+            Dict[str, Any]: 含 success/user 的结果，user 为接口 data 字段
+        """
+        try:
+            resp = session.get(f'{self.base_url}/api/user/self', timeout=self.timeout)
+            body = self._json_of(resp)
+        except Exception as exc:
+            return {'success': False, 'error': f'查询用户信息失败: {exc}'}
+
+        message = str(body.get('message') or '')
+        if not body.get('success'):
+            if resp.status_code == 401 or 'New-Api-User' in message:
+                return {
+                    'success': False,
+                    'error': '登录态无效，或缺少用户 ID（请在账号配置中填写 user_id）',
+                }
+            return {'success': False, 'error': message or '查询用户信息失败'}
+        return {'success': True, 'user': body.get('data') or {}}
+
+    def quota_to_usd(self, quota: Any) -> float:
+        """把站点额度换算为美元（换算比例取自 /api/status 的 quota_per_unit）"""
+        try:
+            return round(float(quota) / self._quota_per_unit, 2)
+        except (TypeError, ValueError):
+            return 0.0

--- a/script/agentrouter/main.py
+++ b/script/agentrouter/main.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+new Env('AgentRouter签到');
+cron: 20 9 * * *
+"""
+
+"""
+Agent Router（ps.air-outer.com）每日签到脚本
+
+签到原理：该站点没有独立签到入口，额度在**登录时**发放（官方 FAQ：「签到领 $25 额度」
+需要退出后重新登录才会到账）。脚本因此每天完整重走一次 GitHub OAuth 登录：
+
+    站点 /api/oauth/state -> GitHub 授权换 code -> 站点 /api/oauth/github 登录 -> 额度到账
+
+GitHub 登录态由配置提供（github_cookies 或 github_session），不读取任何浏览器数据。
+GitHub 回调域名为 agentrouter.org（境内不通），脚本只从其跳转地址中提取 code，
+随后统一用配置中的 base_url（默认 https://ps.air-outer.com）完成登录。
+
+配置示例（config/token.json 的 agentrouter 节点）：
+{
+  "agentrouter": {
+    "accounts": [
+      {
+        "account_name": "erma0",
+        "github_cookies": "user_session=xxx; __Host-user_session_same_site=xxx; logged_in=yes",
+        "base_url": "https://ps.air-outer.com"
+      }
+    ]
+  }
+}
+
+Author: Assistant
+Date: 2026-09-10
+"""
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from api import DEFAULT_BASE_URL, AgentRouterAPI
+from notification import NotificationSound, send_notification
+
+# 多账号之间的间隔（秒），避免短时间内连续请求
+ACCOUNT_INTERVAL_SECONDS = 5
+
+
+class AgentRouterTasks:
+    """Agent Router 签到任务执行类"""
+
+    def __init__(self, config_path: str = None):
+        if config_path is None:
+            self.config_path = project_root / 'config' / 'token.json'
+        else:
+            self.config_path = Path(config_path)
+
+        self.accounts: List[Dict[str, Any]] = []
+        self.account_results: List[Dict[str, Any]] = []
+        self.logger = self._setup_logger()
+        self._init_accounts()
+
+    def _setup_logger(self) -> logging.Logger:
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+
+        if not logger.handlers:
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(logging.INFO)
+            console_handler.setFormatter(logging.Formatter(
+                '%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S'))
+            logger.addHandler(console_handler)
+
+        return logger
+
+    def _init_accounts(self):
+        """从配置文件的 agentrouter 节点读取账号信息"""
+        if not self.config_path.exists():
+            raise FileNotFoundError(f'配置文件不存在: {self.config_path}')
+
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f'配置文件 JSON 解析失败: {exc}')
+
+        self.accounts = (config_data.get('agentrouter') or {}).get('accounts', [])
+        if not self.accounts:
+            self.logger.warning('配置文件中没有找到 agentrouter 账号信息')
+        else:
+            self.logger.info(f'成功加载 {len(self.accounts)} 个账号配置')
+
+    def _build_api(self, account_info: Dict[str, Any]) -> AgentRouterAPI:
+        return AgentRouterAPI(
+            base_url=account_info.get('base_url') or DEFAULT_BASE_URL,
+            github_cookies=account_info.get('github_cookies'),
+            github_session=account_info.get('github_session') or '',
+            user_id=account_info.get('user_id') or '',
+            proxy=account_info.get('proxy') or '',
+            verify=account_info.get('verify'),
+        )
+
+    def _describe_user(self, api: AgentRouterAPI, session) -> Dict[str, Any]:
+        """查询登录后的账号信息，返回额度摘要"""
+        info = api.get_user_self(session)
+        if not info.get('success'):
+            return {'success': False, 'error': info.get('error')}
+
+        user = info.get('user') or {}
+        quota = user.get('quota')
+        summary = {
+            'success': True,
+            'display_name': user.get('display_name') or user.get('username') or '',
+            'quota': quota,
+            'used_quota': user.get('used_quota'),
+            'quota_usd': api.quota_to_usd(quota),
+        }
+        return summary
+
+    def process_account(self, account_index: int, account_info: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        处理单个账号的签到（即重新登录）
+
+        Args:
+            account_index (int): 账号下标
+            account_info (Dict[str, Any]): 账号配置
+
+        Returns:
+            Dict[str, Any]: 处理结果
+        """
+        account_name = account_info.get('account_name') or f'账号{account_index + 1}'
+        self.logger.info(f"\n{'=' * 60}\n开始处理账号: {account_name}\n{'=' * 60}")
+
+        result: Dict[str, Any] = {
+            'account_name': account_name,
+            'success': False,
+            'message': '',
+            'token_error': False,
+            'quota_usd': None,
+            'checked_in': None,
+        }
+
+        api = self._build_api(account_info)
+        self.logger.info(f'{account_name} - 站点: {api.base_url}')
+
+        # 登录即签到：重走一次 GitHub OAuth 登录，服务端在登录流程中发放额度
+        self.logger.info(f'{account_name} - 通过 GitHub OAuth 重新登录以触发签到')
+        login = api.login_by_github()
+
+        if not login.get('success'):
+            result['message'] = login.get('error', '登录失败')
+            result['token_error'] = login.get('error_type') in ('missing_credential', 'auth_failed')
+            self.logger.error(f"❌ {account_name}: {result['message']}")
+            return result
+
+        summary = self._describe_user(api, login['session'])
+        result['success'] = True
+        result['mode'] = login.get('mode', '')
+        result['checked_in'] = login.get('checked_in')
+        result['message'] = ('签到成功，新增额度已到账' if login.get('checked_in')
+                             else '登录成功（今日签到状态：未标记到账）')
+        if summary.get('success'):
+            result['quota_usd'] = summary.get('quota_usd')
+            result['display_name'] = summary.get('display_name')
+            result['message'] += f"（当前余额 ${summary.get('quota_usd')}）"
+        else:
+            self.logger.warning(f"⚠️ {account_name}: 签到已完成，但查询余额失败"
+                                f"（{summary.get('error')}）")
+        self.logger.info(f"✅ {account_name}: {result['message']}")
+        return result
+
+    def run(self, dry_run: bool = False):
+        """执行所有账号的签到"""
+        if not self.accounts:
+            self.logger.error('没有可处理的账号，请检查配置')
+            return
+
+        if dry_run:
+            self.logger.info('[dry-run] 仅校验配置，不执行登录')
+            for index, account in enumerate(self.accounts):
+                name = account.get('account_name') or f'账号{index + 1}'
+                has_github = bool(account.get('github_cookies') or account.get('github_session'))
+                self.logger.info(f'{name}: GitHub登录态={has_github}')
+            return
+
+        for index, account in enumerate(self.accounts):
+            self.account_results.append(self.process_account(index, account))
+            if index < len(self.accounts) - 1:
+                time.sleep(ACCOUNT_INTERVAL_SECONDS)
+
+        self._send_notification()
+
+    def _send_notification(self):
+        """汇总并发送推送通知"""
+        if not self.account_results:
+            return
+
+        total = len(self.account_results)
+        success = sum(1 for r in self.account_results if r['success'])
+        failed = total - success
+
+        lines = [
+            f'📊 总账号数: {total}',
+            f'✅ 签到成功: {success}',
+            f'❌ 签到失败: {failed}',
+            '',
+            '📋 详细结果:',
+        ]
+        for result in self.account_results:
+            status = '✅' if result['success'] else '❌'
+            lines.append(f"{status} {result['account_name']}: {result['message']}")
+            if result.get('display_name'):
+                lines.append(f"    👤 账号: {result['display_name']}")
+            if result.get('quota_usd') is not None:
+                lines.append(f"    💰 当前余额: ${result['quota_usd']}")
+
+        try:
+            send_notification(
+                title='AgentRouter签到结果通知',
+                content='\n'.join(lines),
+                sound=NotificationSound.BIRDSONG,
+            )
+            self.logger.info('✅ 推送通知已发送')
+        except Exception as exc:
+            self.logger.warning(f'⚠️ 发送推送通知失败: {exc}')
+
+
+def main():
+    dry_run = '--dry-run' in sys.argv
+    try:
+        AgentRouterTasks().run(dry_run=dry_run)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f'❌ 错误: {exc}')
+        sys.exit(1)
+    except Exception as exc:
+        print(f'❌ 发生未知错误: {exc}')
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/script/trae/README.md
+++ b/script/trae/README.md
@@ -1,0 +1,69 @@
+# Trae CN 每日自动签到
+
+为 Trae CN 账号自动领取每日签到积分，支持多账号。接口参考 cockpit-tools / trae-mate / TRAE-Automatic-sign-in 相关实现。
+
+## 快速使用（推荐：网页会话模式，支持多账号）
+
+1. **安装依赖**
+
+```bash
+pip install requests pycryptodome
+```
+
+2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `X-Cloudide-Session` 的完整值
+
+3. **写入配置**：在 `config/token.json` 的 `trae` 节点添加账号（`token.json` 已在 .gitignore，不会提交）：
+
+```json
+{
+  "trae": {
+    "accounts": [
+      {
+        "account_name": "主号",
+        "session": "粘贴 X-Cloudide-Session 的完整值"
+      }
+    ]
+  }
+}
+```
+
+> 只有 `session` 是必需的，`account_name` 用于通知里认出账号。签到设备 ID 按账号名自动生成，无需填写。`user_id`/`access_token`/`expires_at`/`device_id` 均为可选增强字段（导入去重、桌面令牌回退），没有也不影响网页会话签到。一个账号一条 `session`，互不影响；会话约 14 天有效，过期后日志会提示"请更新 session"，回浏览器重新复制即可。
+
+4. **运行**
+
+```bash
+python script/trae/main.py            # 执行签到
+python script/trae/main.py --dry-run  # 先预览：只查状态不签到
+```
+
+每天定时跑一次即可（Windows 任务计划 或 青龙 cron `30 8 * * *`）。
+
+## 备用：桌面令牌模式（单账号）
+
+如果你没有网页 session，也可以用官方客户端登录态自动导入：
+
+```bash
+python script/trae/import_accounts.py             # 自动导入本机 Trae/cockpit 账号
+python script/trae/import_accounts.py --list      # 先预览
+```
+
+导入后会在 `trae.accounts` 里填好 `access_token`。注意此模式**受设备限制**：一个客户端设备每天通常只能有一个账号签到成功；多账号若提示设备错误，请改用上面的网页会话模式。
+
+## 文件说明
+
+| 文件 | 作用 |
+|------|------|
+| `main.py` | 签到主入口：多账号编排、判重、结果推送 |
+| `api.py` | 接口封装（网页会话 / 桌面令牌） |
+| `import_accounts.py` | 账号导入（官方客户端 / cockpit-tools） |
+| `web_checkin.py` | 单账号快速验证工具：`python web_checkin.py --session "<值>"` |
+
+## 常见问题
+
+- **日志提示"请更新 session"**：session 过期（约 14 天），浏览器重新复制一次即可
+- **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，给它配 `session` 走网页模式即可
+- **结果推送**：复用项目统一推送（`config/notification.json` 配置）
+
+---
+
+**免责声明**：本脚本仅供学习交流使用，使用产生的一切后果由使用者自行承担。

--- a/script/trae/README.md
+++ b/script/trae/README.md
@@ -10,7 +10,7 @@
 pip install requests pycryptodome
 ```
 
-2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `sessionid` 的值（约 60 天有效）
+2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `sessionid` 的值（约 60 天有效）。**只需这一个 cookie**，`sid_tt`/`uid_tt`/`passport_*`/`X-Cloudide-Session` 等均不需要。
 
 3. **写入配置**：在 `config/token.json` 的 `trae` 节点添加账号（`token.json` 已在 .gitignore，不会提交）：
 
@@ -27,7 +27,7 @@ pip install requests pycryptodome
 }
 ```
 
-> 只需 `refresh_cookies`（里面填 `sessionid`）一个值即可。脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 `X-Cloudide-Session`（与浏览器打开 trae.cn 的续期链路一致），再换 JWT 签到，因此 `session`/`sid_tt`/`uid_tt` 等都不需要配置，约 60 天不用手工更新。`account_name` 用于通知里认出账号；`user_id`/`access_token`/`expires_at`/`device_id` 为可选增强字段（导入去重、桌面令牌回退），没有也不影响签到。
+> 只需 `refresh_cookies`（里面填 `sessionid`）一个值即可，**不需要再填旧式的 `session`（X-Cloudide-Session）**。脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 `X-Cloudide-Session`（与浏览器打开 trae.cn 的续期链路一致），再换 JWT 签到，因此 `session`/`sid_tt`/`uid_tt` 等都不需要配置，约 60 天不用手工更新。`account_name` 用于通知里认出账号；`user_id`/`access_token`/`expires_at`/`device_id` 为可选增强字段（导入去重、桌面令牌回退），没有也不影响签到。
 
 4. **运行**
 
@@ -61,6 +61,8 @@ python script/trae/import_accounts.py --list      # 先预览
 ## 常见问题
 
 - **日志提示"已用长效 Cookie 刷新 session"**：正常，脚本每次运行自动续期，无需手工更新
+- **需要配多少个 cookie？**：只需 `sessionid` 一个（约 60 天有效）。`sid_tt`/`uid_tt`/`passport_*`/`X-Cloudide-Session` 等均已实测可去掉，不填也不影响刷新与签到
+- **还要填旧式的 `session` 吗？**：不用。配了 `refresh_cookies` 后脚本自动刷新并填充 `X-Cloudide-Session`，`session` 字段可留空或删除
 - **日志提示"refresh_cookies 失效"**：`sessionid` 失效（约 60 天），回浏览器重新复制 `sessionid`
 - **日志提示"请更新 session"**：账号只配了旧式 `session`（未配 `refresh_cookies`）且已过期，补配 `refresh_cookies` 即可
 - **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，配 `refresh_cookies` 走网页模式即可

--- a/script/trae/README.md
+++ b/script/trae/README.md
@@ -20,14 +20,14 @@ pip install requests pycryptodome
     "accounts": [
       {
         "account_name": "主号",
-        "refresh_cookies": "sessionid=粘贴 sessionid 的值"
+        "sessionid": "粘贴 sessionid 的值"
       }
     ]
   }
 }
 ```
 
-> 只需 `refresh_cookies`（里面填 `sessionid`）一个值即可，**不需要再填旧式的 `session`（X-Cloudide-Session）**。脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 `X-Cloudide-Session`（与浏览器打开 trae.cn 的续期链路一致），再换 JWT 签到，因此 `session`/`sid_tt`/`uid_tt` 等都不需要配置，约 60 天不用手工更新。`account_name` 用于通知里认出账号；`user_id`/`access_token`/`expires_at`/`device_id` 为可选增强字段（导入去重、桌面令牌回退），没有也不影响签到。
+> 只需 `sessionid` 一个字段（值填浏览器 Cookie 里的 `sessionid`）即可，**不需要再填旧式的 `session`（X-Cloudide-Session）**。脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 `X-Cloudide-Session`（与浏览器打开 trae.cn 的续期链路一致），再换 JWT 签到，因此 `session`/`sid_tt`/`uid_tt` 等都不需要配置，约 60 天不用手工更新。`account_name` 用于通知里认出账号；`user_id`/`access_token`/`expires_at`/`device_id` 为可选增强字段（导入去重、桌面令牌回退），没有也不影响签到。
 
 4. **运行**
 
@@ -62,10 +62,10 @@ python script/trae/import_accounts.py --list      # 先预览
 
 - **日志提示"已用长效 Cookie 刷新 session"**：正常，脚本每次运行自动续期，无需手工更新
 - **需要配多少个 cookie？**：只需 `sessionid` 一个（约 60 天有效）。`sid_tt`/`uid_tt`/`passport_*`/`X-Cloudide-Session` 等均已实测可去掉，不填也不影响刷新与签到
-- **还要填旧式的 `session` 吗？**：不用。配了 `refresh_cookies` 后脚本自动刷新并填充 `X-Cloudide-Session`，`session` 字段可留空或删除
-- **日志提示"refresh_cookies 失效"**：`sessionid` 失效（约 60 天），回浏览器重新复制 `sessionid`
-- **日志提示"请更新 session"**：账号只配了旧式 `session`（未配 `refresh_cookies`）且已过期，补配 `refresh_cookies` 即可
-- **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，配 `refresh_cookies` 走网页模式即可
+- **还要填旧式的 `session` 吗？**：不用。配了 `sessionid` 后脚本自动刷新并填充 `X-Cloudide-Session`，`session` 字段可留空或删除
+- **日志提示"sessionid 失效"**：`sessionid` 失效（约 60 天），回浏览器重新复制 `sessionid`
+- **日志提示"请更新 session"**：账号只配了旧式 `session`（未配 `sessionid`）且已过期，补配 `sessionid` 即可
+- **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，配 `sessionid` 走网页模式即可
 - **结果推送**：复用项目统一推送（`config/notification.json` 配置）
 
 ---

--- a/script/trae/README.md
+++ b/script/trae/README.md
@@ -10,7 +10,7 @@
 pip install requests pycryptodome
 ```
 
-2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `X-Cloudide-Session` 的完整值
+2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `X-Cloudide-Session` 的完整值；同时复制 `sessionid`、`sid_tt`、`uid_tt` 三个值（约 60 天有效）填入 `refresh_cookies`
 
 3. **写入配置**：在 `config/token.json` 的 `trae` 节点添加账号（`token.json` 已在 .gitignore，不会提交）：
 
@@ -20,14 +20,15 @@ pip install requests pycryptodome
     "accounts": [
       {
         "account_name": "主号",
-        "session": "粘贴 X-Cloudide-Session 的完整值"
+        "session": "粘贴 X-Cloudide-Session 的完整值",
+        "refresh_cookies": "sessionid=xxx; sid_tt=xxx; uid_tt=xxx"
       }
     ]
   }
 }
 ```
 
-> 只有 `session` 是必需的，`account_name` 用于通知里认出账号。签到设备 ID 按账号名自动生成，无需填写。`user_id`/`access_token`/`expires_at`/`device_id` 均为可选增强字段（导入去重、桌面令牌回退），没有也不影响网页会话签到。一个账号一条 `session`，互不影响；会话约 14 天有效，过期后日志会提示"请更新 session"，回浏览器重新复制即可。
+> 只有 `session` 是必需的，`account_name` 用于通知里认出账号。签到设备 ID 自动随机生成，无需填写。`refresh_cookies`（可选但推荐）：配置后脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 session（与浏览器打开 trae.cn 的续期链路一致），session 过期也能自动续期，约 60 天不失效；不配置则 session 约 1 天过期，需回浏览器重新复制。`user_id`/`access_token`/`expires_at`/`device_id` 均为可选增强字段（导入去重、桌面令牌回退），没有也不影响网页会话签到。
 
 4. **运行**
 
@@ -60,7 +61,9 @@ python script/trae/import_accounts.py --list      # 先预览
 
 ## 常见问题
 
-- **日志提示"请更新 session"**：session 过期（约 14 天），浏览器重新复制一次即可
+- **日志提示"已用长效 Cookie 刷新 session"**：正常，脚本每次运行自动续期，无需手工更新
+- **日志提示"刷新登录态失败"**：`refresh_cookies` 失效（约 60 天），回浏览器重新复制 `sessionid`/`sid_tt`/`uid_tt`
+- **日志提示"请更新 session"**：未配置 `refresh_cookies` 且 session 过期（约 1 天），浏览器重新复制一次即可；配置 `refresh_cookies` 后不会再出现
 - **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，给它配 `session` 走网页模式即可
 - **结果推送**：复用项目统一推送（`config/notification.json` 配置）
 

--- a/script/trae/README.md
+++ b/script/trae/README.md
@@ -10,7 +10,7 @@
 pip install requests pycryptodome
 ```
 
-2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `X-Cloudide-Session` 的完整值；同时复制 `sessionid`、`sid_tt`、`uid_tt` 三个值（约 60 天有效）填入 `refresh_cookies`
+2. **获取账号会话**：浏览器登录 https://www.trae.cn → F12 → 应用(Application) → Cookies → 复制 `sessionid` 的值（约 60 天有效）
 
 3. **写入配置**：在 `config/token.json` 的 `trae` 节点添加账号（`token.json` 已在 .gitignore，不会提交）：
 
@@ -20,15 +20,14 @@ pip install requests pycryptodome
     "accounts": [
       {
         "account_name": "主号",
-        "session": "粘贴 X-Cloudide-Session 的完整值",
-        "refresh_cookies": "sessionid=xxx; sid_tt=xxx; uid_tt=xxx"
+        "refresh_cookies": "sessionid=粘贴 sessionid 的值"
       }
     ]
   }
 }
 ```
 
-> 只有 `session` 是必需的，`account_name` 用于通知里认出账号。签到设备 ID 自动随机生成，无需填写。`refresh_cookies`（可选但推荐）：配置后脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 session（与浏览器打开 trae.cn 的续期链路一致），session 过期也能自动续期，约 60 天不失效；不配置则 session 约 1 天过期，需回浏览器重新复制。`user_id`/`access_token`/`expires_at`/`device_id` 均为可选增强字段（导入去重、桌面令牌回退），没有也不影响网页会话签到。
+> 只需 `refresh_cookies`（里面填 `sessionid`）一个值即可。脚本每次运行先调 `/cloudide/api/v3/trae/Login` 自动刷新 `X-Cloudide-Session`（与浏览器打开 trae.cn 的续期链路一致），再换 JWT 签到，因此 `session`/`sid_tt`/`uid_tt` 等都不需要配置，约 60 天不用手工更新。`account_name` 用于通知里认出账号；`user_id`/`access_token`/`expires_at`/`device_id` 为可选增强字段（导入去重、桌面令牌回退），没有也不影响签到。
 
 4. **运行**
 
@@ -62,9 +61,9 @@ python script/trae/import_accounts.py --list      # 先预览
 ## 常见问题
 
 - **日志提示"已用长效 Cookie 刷新 session"**：正常，脚本每次运行自动续期，无需手工更新
-- **日志提示"刷新登录态失败"**：`refresh_cookies` 失效（约 60 天），回浏览器重新复制 `sessionid`/`sid_tt`/`uid_tt`
-- **日志提示"请更新 session"**：未配置 `refresh_cookies` 且 session 过期（约 1 天），浏览器重新复制一次即可；配置 `refresh_cookies` 后不会再出现
-- **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，给它配 `session` 走网页模式即可
+- **日志提示"refresh_cookies 失效"**：`sessionid` 失效（约 60 天），回浏览器重新复制 `sessionid`
+- **日志提示"请更新 session"**：账号只配了旧式 `session`（未配 `refresh_cookies`）且已过期，补配 `refresh_cookies` 即可
+- **日志提示"缺少签到设备 device_id"**：该账号走的是桌面令牌模式但没有可用设备，配 `refresh_cookies` 走网页模式即可
 - **结果推送**：复用项目统一推送（`config/notification.json` 配置）
 
 ---

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Trae CN 签到 API 模块
+
+签到积分接口仅存在于 Trae CN（api.trae.cn），适配官方接口约定：
+- 签到状态: POST /trae/api/v2/ug/checkin_credits/status (body "{}")
+- 领取积分: POST /trae/api/v2/ug/checkin_credits/claim    (body "{}")
+
+认证与请求头对齐 cockpit-tools PR #2179 (feat/trae-cn-checkin-credits)：
+- Authorization: Cloud-IDE-JWT <access_token>（不是 Bearer）
+- User-Agent: Trae/1.0.0 antigravity-cockpit-tools
+- x-device-id: 该账号自己注册的设备 ID（本机客户端 icube-dc 后缀的 16 位数字）。
+  注意：签到按「账号 × 设备」校验，多账号共用同一设备或使用伪造/随机设备会被拒
+  （code=9074/9095）；状态查询接口不校验设备。
+
+响应约定：扁平 JSON，仅 code == 0 视为成功。
+- 状态: {"code":0,"checked_in":true,"credits":150,"enable":true,"message":"..."}，credits 为单日奖励口径参考
+- 领取: {"code":0,"credits":150,"message":"..."}，credits 为本次获得的积分
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+# 签到接口仅存在于 Trae CN 域（api.trae.cn），国际版 Trae 无此接口
+BASE_URL = 'https://api.trae.cn/trae/api/v2/ug'
+
+CHECKIN_STATUS_PATH = '/checkin_credits/status'
+CHECKIN_CLAIM_PATH = '/checkin_credits/claim'
+
+# 与 cockpit-tools 官方客户端行为保持一致
+DEFAULT_USER_AGENT = 'Trae/1.0.0 antigravity-cockpit-tools'
+
+# 认证类业务错误码：命中即视为凭证失效（令牌过期/被拒），交由上层提示更新
+# 1001 实测文案 "We're sorry, but we are not able to authenticate you."
+AUTH_ERROR_CODES = {401, 1001, 1002, 1003, 10085}
+# 认证失败文案关键词（对 message 小写后比对，中文不受 lower 影响）
+AUTH_ERROR_HINTS = ('登录', '过期', '认证', '未授权', 'authenticate', 'unauthorized')
+
+
+def _parse_code_message(body: Dict[str, Any]) -> str:
+    """宽松提取接口返回的业务提示文案"""
+    message = body.get('message') or body.get('msg') or 'unknown error'
+    if not isinstance(message, str):
+        message = str(message)
+    return message
+
+
+def _is_auth_error(code: Any, message: str) -> bool:
+    """判断业务错误是否属于凭证失效（错误码或文案任一命中）"""
+    if code in AUTH_ERROR_CODES:
+        return True
+    lowered = message.lower()
+    return any(hint in lowered for hint in AUTH_ERROR_HINTS)
+
+
+_session: Optional[requests.Session] = None
+
+
+def _get_session() -> requests.Session:
+    """
+    惰性创建共享请求会话（连接复用 + 自动重试）
+
+    仅对连接错误与 429/5xx 重试，不改动业务响应判定；签到接口按天幂等，重试安全。
+    """
+    global _session
+    if _session is None:
+        retry = Retry(
+            total=3,
+            backoff_factor=0.5,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset({'POST'}),
+            respect_retry_after_header=False,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        _session = requests.Session()
+        _session.mount('https://', adapter)
+    return _session
+
+
+class TraeAPI:
+    """Trae CN 签到 API 类"""
+
+    def __init__(self, access_token: str, device_id: str = '', timeout: int = 30):
+        """
+        初始化 API 类
+
+        Args:
+            access_token (str): Trae CN 访问令牌，对应请求头 Cloud-IDE-JWT
+            device_id (str): 该账号自己注册的设备 ID（16 位数字），对应请求头 x-device-id；
+                领取接口校验设备，状态接口不校验
+            timeout (int): 请求超时时间（秒）
+        """
+        self.access_token = access_token
+        self.device_id = device_id
+        self.timeout = timeout
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers = {
+            'Authorization': f'Cloud-IDE-JWT {self.access_token}',
+            'Accept': 'application/json, text/plain, */*',
+            'Content-Type': 'application/json',
+            'User-Agent': DEFAULT_USER_AGENT,
+        }
+        if self.device_id:
+            headers['x-device-id'] = self.device_id
+        return headers
+
+    def _post(self, path: str) -> Dict[str, Any]:
+        """
+        发送 POST 请求并解析统一响应结构
+
+        Returns:
+            Dict[str, Any]: 包含 success/data/error/error_type/code 的结果字典
+        """
+        url = f'{BASE_URL}{path}'
+        headers = self._build_headers()
+
+        try:
+            response = _get_session().post(url, headers=headers, json={}, timeout=self.timeout)
+        except requests.RequestException as e:
+            return {'success': False, 'error': f'请求 {path} 失败: {e}', 'error_type': 'network'}
+
+        if response.status_code == 401:
+            return {
+                'success': False,
+                'error': '令牌已失效 (http=401)，请重新导入账号',
+                'error_type': 'token_expired',
+            }
+
+        try:
+            body = response.json()
+        except ValueError:
+            return {
+                'success': False,
+                'error': f'解析 {path} 响应失败: {response.text[:200]}',
+                'error_type': 'parse',
+            }
+
+        if not isinstance(body, dict):
+            return {
+                'success': False,
+                'error': f'{path} 响应不是 JSON 对象: {str(body)[:200]}',
+                'error_type': 'parse',
+            }
+
+        if not response.ok:
+            return {
+                'success': False,
+                'error': f'请求 {path} 失败 (http={response.status_code}): {_parse_code_message(body)}',
+                'error_type': 'http',
+            }
+
+        code = body.get('code', -1)
+        if code != 0:
+            # 业务错误（如今日已签到、风控、令牌过期），保留服务端原始提示交由上层判断
+            message = _parse_code_message(body)
+            error_type = 'token_expired' if _is_auth_error(code, message) else 'business'
+            return {
+                'success': False,
+                'error': f'{message} (code={code})',
+                'error_type': error_type,
+                'code': code,
+                'body': body,
+            }
+
+        return {'success': True, 'data': body}
+
+    @staticmethod
+    def _parse_status(data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        解析签到状态响应
+
+        Args:
+            data (Dict[str, Any]): 接口返回的扁平 JSON
+
+        Returns:
+            Dict[str, Any]: 标准化后的签到状态
+        """
+        checked_in = bool(data.get('checked_in', False))
+        # did_checked_in：是否为「本次所用设备」当日签到（checked_in 为账号维度真值；
+        # 若 checked_in=true 而 did_checked_in=false，说明账号已在其它渠道签过，领取为幂等）
+        # credits 为服务端返回的积分参考值（实测对同一时段所有账号一致，为单日奖励口径，
+        # 非累计余额），此处仅原样透传，避免误当余额展示
+        return {
+            'success': True,
+            'checked_in': checked_in,
+            'did_checked_in': bool(data.get('did_checked_in', False)),
+            'credits': data.get('credits') or 0,
+            'extra_credits': data.get('extra_credits'),
+            'enable': bool(data.get('enable', True)),
+            'message': '今日已签到' if checked_in else '今日未签到',
+            'raw': data,
+        }
+
+    def get_checkin_status(self) -> Dict[str, Any]:
+        """
+        查询今日签到状态
+
+        Returns:
+            Dict[str, Any]: 包含 checked_in/credits 的结果字典
+        """
+        result = self._post(CHECKIN_STATUS_PATH)
+        if not result['success']:
+            return {
+                'success': False,
+                'error': result.get('error', '查询签到状态失败'),
+                'error_type': result.get('error_type', 'api'),
+                'code': result.get('code'),
+            }
+        return self._parse_status(result['data'])
+
+    def claim_checkin(self) -> Dict[str, Any]:
+        """
+        领取今日签到积分
+
+        Returns:
+            Dict[str, Any]: 包含 message/credits（本次奖励）的结果字典
+        """
+        result = self._post(CHECKIN_CLAIM_PATH)
+        if not result['success']:
+            return {
+                'success': False,
+                'error': result.get('error', '签到领取失败'),
+                'error_type': result.get('error_type', 'api'),
+                'code': result.get('code'),
+            }
+
+        body = result['data']
+        # 领取成功时服务端返回的 credits 为本次获得的积分（部分响应以 data.points 返回）
+        credits = None
+        data = body.get('data') if isinstance(body.get('data'), dict) else None
+        if data:
+            credits = data.get('points') or data.get('credits')
+        if credits is None:
+            credits = body.get('credits')
+
+        raw_message = body.get('message') or ''
+        if not isinstance(raw_message, str) or raw_message.lower() in ('success', 'ok'):
+            message = '签到成功'
+        else:
+            message = raw_message
+
+        return {
+            'success': True,
+            'message': message,
+            'credits': int(credits) if isinstance(credits, (int, float)) and not isinstance(credits, bool) else None,
+        }
+
+
+# 网页会话模式使用的主机根（GetUserToken 不在 /trae/... 子路径下）
+ROOT_URL = 'https://api.trae.cn'
+GET_TOKEN_PATH = '/cloudide/api/v3/common/GetUserToken'
+
+
+class TraeWebAPI:
+    """
+    Trae CN 网页会话签到 API 类（方案 C，参考 star620 云端思路）
+
+    账号在浏览器登录后获得 HttpOnly Cookie `X-Cloudide-Session`（约 14 天有效），
+    每次运行用它 POST /cloudide/api/v3/common/GetUserToken 换取全新 JWT
+    （网页 JWT 约 8 小时），再走常规签到接口。
+
+    实测：网页链路换来的 JWT + 随机 16 位设备可以正常签到（code=0），
+    不像桌面令牌那样校验客户端注册设备（否则随机设备会 code=9074）。
+    因此多账号各自提供 session 后即可分别每日签到，不受一机一设备限制。
+    """
+
+    def __init__(self, session: str, device_id: str = '', timeout: int = 30):
+        self.session = session
+        self.device_id = device_id
+        self.timeout = timeout
+        self._jwt: Optional[str] = None
+
+    def _fetch_jwt(self) -> Dict[str, Any]:
+        """用 X-Cloudide-Session 换取全新 JWT"""
+        headers = {
+            'Cookie': f'X-Cloudide-Session={self.session}',
+            'Referer': 'https://www.trae.cn/',
+            'Origin': 'https://www.trae.cn',
+            'User-Agent': 'TraeCheckin/1.0',
+            'Accept': 'application/json, text/plain, */*',
+        }
+        try:
+            response = _get_session().post(ROOT_URL + GET_TOKEN_PATH, headers=headers,
+                                           data='{}', timeout=self.timeout)
+        except requests.RequestException as e:
+            return {'success': False, 'error': f'换取 JWT 失败: {e}', 'error_type': 'network'}
+        if response.status_code != 200:
+            return {
+                'success': False,
+                'error': f'换取 JWT 失败 (http={response.status_code})，session 可能已失效',
+                'error_type': 'session_invalid',
+            }
+        try:
+            body = response.json()
+        except ValueError:
+            return {'success': False, 'error': '解析 JWT 响应失败', 'error_type': 'parse'}
+        token = (body.get('Result') or {}).get('Token')
+        if not token:
+            msg = body.get('ResponseMetadata', {}).get('Error', {}).get('Message') or body
+            return {
+                'success': False,
+                'error': f'换取 JWT 失败: {str(msg)[:120]}',
+                'error_type': 'session_invalid',
+            }
+        self._jwt = token
+        return {'success': True, 'jwt': token}
+
+    def _delegate(self, method: str) -> Dict[str, Any]:
+        """构造临时 TraeAPI 并调用指定方法；JWT 失效时换新重试一次"""
+        for attempt in (1, 2):
+            if not self._jwt:
+                fetched = self._fetch_jwt()
+                if not fetched['success']:
+                    return {'success': False, 'error': fetched['error'],
+                            'error_type': fetched['error_type']}
+            api = TraeAPI(access_token=self._jwt, device_id=self.device_id, timeout=self.timeout)
+            result = getattr(api, method)()
+            if result['success'] or result.get('error_type') != 'token_expired' or attempt == 2:
+                return result
+            self._jwt = None  # 强制下次换新后重试
+        return {'success': False, 'error': '网页令牌异常', 'error_type': 'token_expired'}
+
+    def get_checkin_status(self) -> Dict[str, Any]:
+        """查询今日签到状态"""
+        return self._delegate('get_checkin_status')
+
+    def claim_checkin(self) -> Dict[str, Any]:
+        """领取今日签到积分"""
+        return self._delegate('claim_checkin')

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -261,14 +261,14 @@ GET_TOKEN_PATH = '/cloudide/api/v3/common/GetUserToken'
 LOGIN_PATH = '/cloudide/api/v3/trae/Login'
 
 
-def login_refresh(refresh_cookies: str, timeout: int = 30) -> Dict[str, Any]:
+def login_refresh(sessionid: str, timeout: int = 30) -> Dict[str, Any]:
     """
     用长效登录 Cookie 调 /cloudide/api/v3/trae/Login 换取全新 X-Cloudide-Session。
     实测只需 `sessionid` 一个 Cookie（约 60 天有效）即可刷新；浏览器每次打开
     trae.cn 即走此链路自动续期，脚本据此可在 session 过期后自动刷新，配置不再隔天失效。
     """
     headers = {
-        'Cookie': refresh_cookies,
+        'Cookie': f'sessionid={sessionid}',
         'Referer': 'https://www.trae.cn/',
         'Origin': 'https://www.trae.cn',
         'User-Agent': DEFAULT_USER_AGENT,

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -258,6 +258,39 @@ class TraeAPI:
 # 网页会话模式使用的主机根（GetUserToken 不在 /trae/... 子路径下）
 ROOT_URL = 'https://api.trae.cn'
 GET_TOKEN_PATH = '/cloudide/api/v3/common/GetUserToken'
+LOGIN_PATH = '/cloudide/api/v3/trae/Login'
+
+
+def login_refresh(refresh_cookies: str, timeout: int = 30) -> Dict[str, Any]:
+    """
+    用长效登录 Cookie（sessionid/sid_tt/uid_tt 等，约 60 天有效）调 /cloudide/api/v3/trae/Login
+    换取全新 X-Cloudide-Session。浏览器每次打开 trae.cn 即走此链路自动续期，
+    脚本据此可在 session 过期后自动刷新，配置不再隔天失效。
+    """
+    headers = {
+        'Cookie': refresh_cookies,
+        'Referer': 'https://www.trae.cn/',
+        'Origin': 'https://www.trae.cn',
+        'User-Agent': DEFAULT_USER_AGENT,
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json',
+    }
+    try:
+        resp = _get_session().post(ROOT_URL + LOGIN_PATH, headers=headers, json={}, timeout=timeout)
+    except requests.RequestException as e:
+        return {'success': False, 'error': f'刷新登录态失败: {e}', 'error_type': 'network'}
+    if resp.status_code != 200:
+        return {'success': False,
+                'error': f'刷新登录态失败 (http={resp.status_code})，长效 Cookie 可能已失效',
+                'error_type': 'session_invalid'}
+    new_session = None
+    for key, value in resp.headers.items():
+        if key.lower() == 'set-cookie' and value.strip().startswith('X-Cloudide-Session='):
+            new_session = value.strip().split('=', 1)[1].split(';', 1)[0].strip()
+            break
+    if not new_session:
+        return {'success': False, 'error': '刷新登录态响应缺少 X-Cloudide-Session', 'error_type': 'parse'}
+    return {'success': True, 'session': new_session}
 
 
 class TraeWebAPI:

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -9,7 +9,7 @@ Trae CN 签到 API 模块
 
 认证与请求头对齐官方网页端请求（浏览器访问 trae.cn 时对 api.trae.cn 的实际请求）：
 - Authorization: Cloud-IDE-JWT <access_token>（不是 Bearer）
-- User-Agent: 浏览器 UA（Chrome/152，与官方网页端一致）
+- User-Agent: 官方桌面客户端真实 UA（VSCode 1.107.1 (TRAE SOLO CN)，抓包确认）
 - x-device-id: 该账号自己注册的设备 ID（本机客户端 icube-dc 后缀的 16 位数字）。
   注意：签到按「账号 × 设备」校验，多账号共用同一设备或使用伪造/随机设备会被拒
   （code=9074/9095）；状态查询接口不校验设备。
@@ -34,10 +34,8 @@ BASE_URL = 'https://api.trae.cn/trae/api/v2/ug'
 CHECKIN_STATUS_PATH = '/checkin_credits/status'
 CHECKIN_CLAIM_PATH = '/checkin_credits/claim'
 
-# 与官方网页端请求一致（浏览器访问 trae.cn 时对 api.trae.cn 的实际 UA）
-DEFAULT_USER_AGENT = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                      'AppleWebKit/537.36 (KHTML, like Gecko) '
-                      'Chrome/152.0.0.0 Safari/537.36')
+# 官方桌面客户端（TRAE SOLO CN）真实 UA，抓包确认；实测全链路可用
+DEFAULT_USER_AGENT = 'VSCode 1.107.1 (TRAE SOLO CN)'
 
 # 认证类业务错误码：命中即视为凭证失效（令牌过期/被拒），交由上层提示更新
 # 1001 实测文案 "We're sorry, but we are not able to authenticate you."

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -7,9 +7,9 @@ Trae CN 签到 API 模块
 - 签到状态: POST /trae/api/v2/ug/checkin_credits/status (body "{}")
 - 领取积分: POST /trae/api/v2/ug/checkin_credits/claim    (body "{}")
 
-认证与请求头对齐 cockpit-tools PR #2179 (feat/trae-cn-checkin-credits)：
+认证与请求头对齐官方网页端请求（浏览器访问 trae.cn 时对 api.trae.cn 的实际请求）：
 - Authorization: Cloud-IDE-JWT <access_token>（不是 Bearer）
-- User-Agent: Trae/1.0.0 antigravity-cockpit-tools
+- User-Agent: 浏览器 UA（Chrome/152，与官方网页端一致）
 - x-device-id: 该账号自己注册的设备 ID（本机客户端 icube-dc 后缀的 16 位数字）。
   注意：签到按「账号 × 设备」校验，多账号共用同一设备或使用伪造/随机设备会被拒
   （code=9074/9095）；状态查询接口不校验设备。
@@ -34,8 +34,10 @@ BASE_URL = 'https://api.trae.cn/trae/api/v2/ug'
 CHECKIN_STATUS_PATH = '/checkin_credits/status'
 CHECKIN_CLAIM_PATH = '/checkin_credits/claim'
 
-# 与 cockpit-tools 官方客户端行为保持一致
-DEFAULT_USER_AGENT = 'Trae/1.0.0 antigravity-cockpit-tools'
+# 与官方网页端请求一致（浏览器访问 trae.cn 时对 api.trae.cn 的实际 UA）
+DEFAULT_USER_AGENT = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                      'AppleWebKit/537.36 (KHTML, like Gecko) '
+                      'Chrome/152.0.0.0 Safari/537.36')
 
 # 认证类业务错误码：命中即视为凭证失效（令牌过期/被拒），交由上层提示更新
 # 1001 实测文案 "We're sorry, but we are not able to authenticate you."
@@ -318,7 +320,7 @@ class TraeWebAPI:
             'Cookie': f'X-Cloudide-Session={self.session}',
             'Referer': 'https://www.trae.cn/',
             'Origin': 'https://www.trae.cn',
-            'User-Agent': 'TraeCheckin/1.0',
+            'User-Agent': DEFAULT_USER_AGENT,
             'Accept': 'application/json, text/plain, */*',
         }
         try:

--- a/script/trae/api.py
+++ b/script/trae/api.py
@@ -263,9 +263,9 @@ LOGIN_PATH = '/cloudide/api/v3/trae/Login'
 
 def login_refresh(refresh_cookies: str, timeout: int = 30) -> Dict[str, Any]:
     """
-    用长效登录 Cookie（sessionid/sid_tt/uid_tt 等，约 60 天有效）调 /cloudide/api/v3/trae/Login
-    换取全新 X-Cloudide-Session。浏览器每次打开 trae.cn 即走此链路自动续期，
-    脚本据此可在 session 过期后自动刷新，配置不再隔天失效。
+    用长效登录 Cookie 调 /cloudide/api/v3/trae/Login 换取全新 X-Cloudide-Session。
+    实测只需 `sessionid` 一个 Cookie（约 60 天有效）即可刷新；浏览器每次打开
+    trae.cn 即走此链路自动续期，脚本据此可在 session 过期后自动刷新，配置不再隔天失效。
     """
     headers = {
         'Cookie': refresh_cookies,

--- a/script/trae/import_accounts.py
+++ b/script/trae/import_accounts.py
@@ -1,0 +1,919 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Trae CN 账号导入工具与设备 ID 解析
+
+将本机已有的 Trae CN 账号批量导入到 config/token.json 的 trae 节点。
+
+支持的导入来源：
+1. 官方 Trae CN / Trae 客户端（自动探测，读取 User/globalStorage/storage.json 中
+   iCubeAuthInfo://icube.cloudide 的 accessToken，仅导入 AIRegion=CN 账号）
+2. cockpit-tools 数据目录（批量导入其 trae_accounts 目录，AES-256-GCM 自动解密）
+
+签到接口只存在于 Trae CN（api.trae.cn），故本工具只保留 CN 账号；
+账号按 user_id 去重，同一账号保留令牌有效期（expires_at）最新的来源。
+
+使用示例：
+    python import_accounts.py                      # 官方客户端 + cockpit-tools 自动探测导入
+    python import_accounts.py --list               # 仅预览，不写入配置
+    python import_accounts.py --path D:/xxx.json   # 从指定文件/目录导入
+"""
+
+import argparse
+import base64
+import json
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+project_root = Path(__file__).resolve().parent.parent.parent
+CONFIG_PATH = project_root / "config" / "token.json"
+
+# cockpit-tools 的 Trae 账号目录与密钥文件名
+ACCOUNTS_DIR_NAME = "trae_accounts"
+ACCOUNTS_INDEX_FILE = "trae_accounts.json"
+KEY_FILE_NAME = "secure-account-storage.key"
+
+# 官方 Trae 客户端 storage.json 的登录态与设备键
+AUTH_STORAGE_KEY = "iCubeAuthInfo://icube.cloudide"
+DEVICE_STORAGE_KEY_PREFIX = "iCubeAuthInfo://icube-dc:"
+
+# 本机签到设备 ID 持久化文件名（与账号配置同目录，无需入库）
+DEVICE_ID_FILE = "trae_device_id.txt"
+
+# 各平台客户端的 %APPDATA% 目录名（CN 客户端优先，设备 ID 解析顺序与此一致）
+CN_APP_DIRS = ["TRAE SOLO CN", "Trae CN"]
+APP_DIRS = CN_APP_DIRS + ["TRAE SOLO", "Trae"]
+
+try:
+    from Crypto.Cipher import AES
+    HAS_CRYPTO = True
+except ImportError:
+    HAS_CRYPTO = False
+
+# HAS_CRYPTO 为 False 时只提示一次，避免逐文件刷屏
+_crypto_warned = False
+
+# ============ 客户端登录态解密（AES 信封） ============
+# 部分客户端版本（如 TRAE SOLO CN）把 iCubeAuthInfo://icube.cloudide 存为 AES 信封而非明文
+# JSON。信封 = HEADER(6) + randomKey(32) + AES-128-CBC( SHA512(payload) ‖ payload )，
+# key/iv = SHA512( SHA512(randomKey) ‖ (LEFT_SECRET⊕RIGHT_SECRET) ) 前 32 字节（对齐 trae-mate）。
+
+_ENVELOPE_HEADER = bytes([116, 99, 5, 16, 0, 0])
+_LEFT_SECRET = bytes([
+    82, 9, 106, 213, 48, 54, 165, 56, 191, 64, 163, 158, 129, 243, 215, 251, 124, 227, 57, 130,
+    155, 47, 255, 135, 52, 142, 67, 68, 196, 222, 233, 203, 84, 123, 148, 50, 166, 194, 35, 61,
+    238, 76, 149, 11, 66, 250, 195, 78, 8, 46, 161, 102, 40, 217, 36, 178, 118, 91, 162, 73, 109,
+    139, 209, 37,
+])
+_RIGHT_SECRET = bytes([
+    31, 221, 168, 51, 136, 7, 199, 49, 177, 18, 16, 89, 39, 128, 236, 95, 96, 81, 127, 169, 25,
+    181, 74, 13, 45, 229, 122, 159, 147, 201, 156, 239, 160, 224, 59, 77, 174, 42, 245, 176, 200,
+    235, 187, 60, 131, 83, 153, 97, 23, 43, 4, 126, 186, 119, 214, 38, 225, 105, 20, 99, 85, 33,
+    12, 125,
+])
+
+
+def _sha512(data: bytes) -> bytes:
+    import hashlib
+    return hashlib.sha512(data).digest()
+
+
+def _unpad_pkcs7(data: bytes) -> Optional[bytes]:
+    if not data:
+        return None
+    pad = data[-1]
+    if pad == 0 or pad > 16 or data[-pad:] != bytes([pad]) * pad:
+        return None
+    return data[:-pad]
+
+
+def decrypt_trae_auth_envelope(encoded: str) -> Optional[Dict[str, Any]]:
+    """解密客户端 AES 信封格式的登录态，返回 payload JSON；失败返回 None"""
+    if not HAS_CRYPTO:
+        return None
+    try:
+        envelope = base64.b64decode(encoded)
+        if len(envelope) <= 38 or envelope[0:6] != _ENVELOPE_HEADER:
+            return None
+        random_key = envelope[6:38]
+        secret = bytes(a ^ b for a, b in zip(_LEFT_SECRET, _RIGHT_SECRET))
+        derived = _sha512(_sha512(random_key) + secret)
+        cipher = AES.new(derived[0:16], AES.MODE_CBC, iv=derived[16:32])
+        plaintext = _unpad_pkcs7(cipher.decrypt(envelope[38:]))
+        if plaintext is None or len(plaintext) < 64:
+            return None
+        payload = plaintext[64:]
+        if _sha512(payload) != plaintext[:64]:
+            return None
+        parsed = json.loads(payload.decode('utf-8'))
+        return parsed if isinstance(parsed, dict) else None
+    except Exception:
+        return None
+
+
+def parse_storage_auth_value(raw_value: str) -> Optional[Dict[str, Any]]:
+    """解析客户端登录态值：明文 JSON 优先，其次 AES 信封（兼容不同客户端版本）"""
+    if raw_value.lstrip().startswith('{'):
+        try:
+            parsed = json.loads(raw_value)
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return decrypt_trae_auth_envelope(raw_value)
+
+
+def _warn_no_crypto() -> None:
+    """遇到加密账号但缺少 pycryptodome 时给出一次性安装提示"""
+    global _crypto_warned
+    if not _crypto_warned:
+        _crypto_warned = True
+        print("⚠️  检测到加密存储的账号，但缺少 pycryptodome，无法解密（pip install pycryptodome）")
+
+
+# ============ 官方客户端读取 ============
+
+
+def _appdata_roots() -> List[Path]:
+    """返回 %APPDATA% 目录（官方客户端默认安装数据目录所在）"""
+    roots: List[Path] = []
+    if sys.platform == 'win32':
+        appdata = os.environ.get('APPDATA')
+        if appdata:
+            roots.append(Path(appdata))
+        # 环境变量缺失时（如计划任务/无登录 Shell）回退到家目录默认位置
+        fallback = Path.home() / 'AppData' / 'Roaming'
+        if fallback not in roots:
+            roots.append(fallback)
+    elif sys.platform == 'darwin':
+        roots.append(Path.home() / 'Library' / 'Application Support')
+    else:
+        xdg = os.environ.get('XDG_CONFIG_HOME')
+        if xdg:
+            roots.append(Path(xdg))
+        roots.append(Path.home() / '.config')
+    return roots
+
+
+def find_local_client_storage_paths() -> List[Tuple[str, Path]]:
+    """
+    定位官方 Trae 客户端 storage.json（含按账号隔离的独立实例目录）
+
+    独立实例目录命名：`<客户端目录名>_<标识>`（官方客户端多开登录生成），
+    例如 `Trae CN_3850969196273683`。这些目录各自登录一个账号并注册了独立设备，
+    需要纳入探测以便自动同步令牌与设备配对。
+
+    Returns:
+        List[Tuple[str, Path]]: (目录名, storage.json 路径) 列表，不存在返回空
+    """
+    results: List[Tuple[str, Path]] = []
+    for root in _appdata_roots():
+        for dir_name in APP_DIRS:
+            storage = root / dir_name / 'User' / 'globalStorage' / 'storage.json'
+            if storage.is_file():
+                results.append((dir_name, storage))
+        # 独立实例目录（Trae CN_xxx / TRAE SOLO CN_xxx / Trae_xxx 等）
+        if not root.is_dir():
+            continue
+        try:
+            children = sorted(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if not child.is_dir():
+                continue
+            name = child.name
+            matched = any(name == base or name.startswith(base + '_') for base in APP_DIRS)
+            if not matched:
+                continue
+            storage = child / 'User' / 'globalStorage' / 'storage.json'
+            if storage.is_file():
+                results.append((name, storage))
+    # 去重（同一 storage 路径可能因大小写/重复根目录出现两次）
+    seen: List[Path] = []
+    deduped: List[Tuple[str, Path]] = []
+    for dir_name, storage in results:
+        if storage in seen:
+            continue
+        seen.append(storage)
+        deduped.append((dir_name, storage))
+    return deduped
+
+
+def _read_storage_key_value(storage_path: Path, key: str) -> Optional[Dict[str, Any]]:
+    """读取 storage.json 中指定键的登录态（兼容明文 JSON 与 AES 信封两种格式）"""
+    try:
+        with open(storage_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    raw = data.get(key)
+    if not isinstance(raw, str):
+        return None
+    return parse_storage_auth_value(raw)
+
+
+def _read_storage_device_id(storage_path: Path) -> str:
+    """
+    读取官方客户端 storage.json 中注册的 ICDRS 数字设备 ID
+
+    键名为 `iCubeAuthInfo://icube-dc:<16位数字>`（该键值是与设备 ID 配套的签名密钥，
+    不参与解析）。注意：同一客户端目录的设备为该目录"最近注册账号"所用，多账号共用
+    同一客户端时会指向同一设备（签到会撞车）。
+    """
+    try:
+        content = storage_path.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        return ''
+    marker = f'"{DEVICE_STORAGE_KEY_PREFIX}'
+    start = content.find(marker)
+    if start < 0:
+        return ''
+    digits = re.match(r'\d+', content[start + len(marker):])
+    return digits.group(0) if digits else ''
+
+
+def scan_client_device_pairs() -> Dict[str, str]:
+    """
+    扫描官方 Trae 客户端，建立 userId → 本机注册设备 ID 的对应关系
+
+    仅当同一份 storage.json 同时存在登录态（auth，含 userId）与 icube-dc 设备时才能
+    确定归属。多账号共用同一客户端（机器级设备）时不区分实例，故「实例目录与主目录
+    共用同一设备」的配对会被跳过——那属于共享设备，无法作为某账号的独立身份。
+    被 cockpit-tools 注销/切号后的客户端目录无法归属，不会出现在结果中。
+
+    Returns:
+        Dict[str, str]: user_id → device_id（仅独立的账号级设备）
+    """
+    pairs: Dict[str, str] = {}
+
+    def _region_ok(auth: Dict[str, Any]) -> bool:
+        region = str(auth.get('AIRegion') or auth.get('userRegion') or '').upper()
+        if not region:
+            host = str(auth.get('host') or '')
+            region = 'CN' if 'api.trae.cn' in host else ('SG' if 'api.trae.ai' in host else '')
+        return region == 'CN'
+
+    # 主目录（无 _ 后缀）上的机器级共享设备集合
+    machine_devices: set = set()
+    for _, storage_path in find_local_client_storage_paths():
+        auth = _read_storage_key_value(storage_path, AUTH_STORAGE_KEY)
+        if not auth or not _region_ok(auth):
+            continue
+        device_id = _read_storage_device_id(storage_path)
+        if device_id:
+            machine_devices.add(device_id)
+
+    for dir_name, storage_path in find_local_client_storage_paths():
+        auth = _read_storage_key_value(storage_path, AUTH_STORAGE_KEY)
+        if not auth or not auth.get('userId') or not _region_ok(auth):
+            continue
+        device_id = _read_storage_device_id(storage_path)
+        if not device_id:
+            continue
+        # 实例目录若与主目录共用同一机器级设备 → 跳过（非独立身份）
+        if '_' in dir_name and device_id in machine_devices:
+            continue
+        pairs[str(auth['userId'])] = device_id
+    return pairs
+
+
+def _parse_expires_at(value: Any) -> Optional[int]:
+    """将 auth 对象中的过期时间规范化为秒级时间戳（兼容秒/毫秒）"""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        ts = int(value)
+    elif isinstance(value, str) and value.strip().lstrip('-').isdigit():
+        ts = int(value.strip())
+    else:
+        return None
+    if ts > 10_000_000_000:  # 毫秒时间戳
+        ts //= 1000
+    return ts
+
+
+def load_accounts_from_local_clients() -> List[Dict[str, Any]]:
+    """
+    从官方 Trae 客户端读取当前登录的 CN 账号
+
+    Returns:
+        List[Dict[str, Any]]: 原始账号数据列表
+    """
+    accounts: List[Dict[str, Any]] = []
+    for dir_name, storage_path in find_local_client_storage_paths():
+        auth = _read_storage_key_value(storage_path, AUTH_STORAGE_KEY)
+        if not auth:
+            continue
+        # 区域判定：明文版在 AIRegion，信封版在 host 中体现（api.trae.cn => CN）
+        region = str(auth.get('AIRegion') or auth.get('userRegion') or '').upper()
+        if not region:
+            host = str(auth.get('host') or '')
+            region = 'CN' if 'api.trae.cn' in host else ('SG' if 'api.trae.ai' in host else '')
+        if region != 'CN':
+            continue
+        access_token = auth.get('accessToken') or auth.get('token')
+        if not access_token:
+            continue
+
+        account_obj = auth.get('account')
+        username = ''
+        if isinstance(account_obj, dict):
+            username = account_obj.get('username') or ''
+
+        # 同一目录内同时存在登录态与 icube-dc 设备时，设备归属该登录账号
+        device_id = _read_storage_device_id(storage_path)
+
+        accounts.append({
+            'user_id': str(auth.get('userId') or ''),
+            'nickname': username,
+            'email': auth.get('email') or 'unknown',
+            'access_token': access_token,
+            'expires_at': _parse_expires_at(auth.get('expiresAt')),
+            'region': 'CN',
+            'source': f'local:{dir_name}',
+            'device_id': device_id,
+        })
+    return accounts
+
+
+# ============ cockpit-tools 数据目录读取 ============
+
+
+def find_cockpit_data_dirs() -> List[Path]:
+    """
+    自动探测本机可能存在的 cockpit-tools 数据目录
+
+    Returns:
+        List[Path]: 包含 Trae 账号数据的候选目录列表
+    """
+    candidates: List[Path] = []
+    home = Path.home()
+
+    roots: List[Path] = []
+    if sys.platform == 'win32':
+        for env_key in ('APPDATA', 'LOCALAPPDATA'):
+            value = os.environ.get(env_key)
+            if value:
+                roots.append(Path(value))
+        roots.append(home)
+        roots.append(home / '.config')
+        roots.append(home / '.local' / 'share')
+    elif sys.platform == 'darwin':
+        roots.append(home / 'Library' / 'Application Support')
+        roots.append(home)
+    else:
+        roots.append(home / '.config')
+        roots.append(home / '.local' / 'share')
+        roots.append(home)
+
+    for root in roots:
+        if not root.is_dir():
+            continue
+        try:
+            for child in root.iterdir():
+                if not child.is_dir():
+                    continue
+                name = child.name.lower()
+                if 'cockpit' in name or 'agtools' in name or 'antigravity' in name:
+                    if (child / ACCOUNTS_DIR_NAME).is_dir() or (child / ACCOUNTS_INDEX_FILE).exists():
+                        candidates.append(child)
+        except PermissionError:
+            continue
+
+    return candidates
+
+
+def find_secure_key(source_dir: Path) -> Optional[Path]:
+    """为给定账号来源目录查找解密用的本地密钥文件（同 workbuddy 模块策略）"""
+    search_bases: List[Path] = [source_dir]
+    if source_dir.name == ACCOUNTS_DIR_NAME:
+        search_bases.append(source_dir.parent)
+    else:
+        search_bases.append(source_dir / ACCOUNTS_DIR_NAME)
+    search_bases.append(source_dir.parent)
+
+    for base in search_bases:
+        candidate = base / KEY_FILE_NAME
+        if candidate.is_file():
+            return candidate
+
+    home = Path.home()
+    for fallback in (
+        home / '.antigravity_cockpit' / KEY_FILE_NAME,
+        home / '.config' / 'cockpit-tools' / KEY_FILE_NAME,
+        home / '.local' / 'share' / 'cockpit-tools' / KEY_FILE_NAME,
+    ):
+        if fallback.is_file():
+            return fallback
+
+    return None
+
+
+def decrypt_record(enc: Dict[str, Any], key: bytes) -> Optional[Dict[str, Any]]:
+    """使用本地密钥解密 AES-256-GCM 加密的账号记录"""
+    if not HAS_CRYPTO:
+        _warn_no_crypto()
+        return None
+    try:
+        nonce = base64.b64decode(enc['nonce'])
+        ct = base64.b64decode(enc['ciphertext'])
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        plain = cipher.decrypt_and_verify(ct[:-16], ct[-16:])
+        return json.loads(plain.decode('utf-8'))
+    except Exception as e:
+        print(f"⚠️  解密失败: {e}")
+        return None
+
+
+def load_accounts_from_cockpit_dir(directory: Path, quiet: bool = False) -> List[Dict[str, Any]]:
+    """
+    从 cockpit-tools 数据目录读取 Trae 账号（兼容明文与 AES-256-GCM 加密）
+
+    Args:
+        directory (Path): cockpit-tools 数据目录（含 trae_accounts 子目录）
+        quiet (bool): True 时不输出警告信息
+
+    Returns:
+        List[Dict[str, Any]]: 原始账号数据列表
+    """
+    accounts_dir = directory / ACCOUNTS_DIR_NAME
+    if not accounts_dir.is_dir():
+        return []
+
+    key_path = find_secure_key(directory)
+    key = None
+    if key_path:
+        try:
+            key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
+        except Exception as e:
+            if not quiet:
+                print(f"⚠️  读取密钥失败: {e}")
+
+    accounts: List[Dict[str, Any]] = []
+    for json_file in sorted(accounts_dir.glob('*.json')):
+        if json_file.name == ACCOUNTS_INDEX_FILE or json_file.name.endswith('.bak'):
+            continue
+        try:
+            with open(json_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            if not quiet:
+                print(f"⚠️  跳过无法解析的文件 {json_file.name}: {e}")
+            continue
+
+        if isinstance(data, dict) and data.get('ciphertext'):
+            if not key:
+                if not quiet:
+                    print(f"⚠️  跳过加密账号 {json_file.name}: 未找到解密密钥 {KEY_FILE_NAME}")
+                continue
+            data = decrypt_record(data, key)
+            if not data:
+                continue
+
+        if not isinstance(data, dict) or not data.get('access_token'):
+            continue
+
+        # 仅保留 CN 账号（cockpit 混存多平台 Trae 账号时过滤掉国际版）
+        auth_raw = data.get('trae_auth_raw')
+        region = ''
+        if isinstance(auth_raw, dict):
+            region = str(auth_raw.get('AIRegion') or '')
+        if region and region.upper() != 'CN':
+            continue
+
+        account_id = data.get('id') or ''
+        user_id = data.get('user_id')
+        if user_id is None:
+            # cockpit 账号结构里 user_id 可能是 int；没有则用账号 id 兜底去重
+            user_id = account_id
+        user_id = str(user_id)
+
+        accounts.append({
+            'account_id': account_id,
+            'user_id': user_id,
+            'nickname': data.get('nickname') or '',
+            'email': data.get('email') or 'unknown',
+            'access_token': data['access_token'],
+            'expires_at': data.get('expires_at'),
+            'region': 'CN',
+            'source': f'cockpit:{directory.name}',
+        })
+    return accounts
+
+
+# ============ 账号合并 ============
+
+
+def account_identity(account: Dict[str, Any]) -> str:
+    """账号唯一标识（user_id），用于导入去重"""
+    return (account.get('user_id') or account.get('email') or account.get('nickname') or '').strip().lower()
+
+
+def _merge_best_expires(account: Dict[str, Any], best_expires: Dict[str, int]) -> bool:
+    """判断候选账号是否为同身份中令牌最新者，是则记录并返回 True"""
+    identity = account_identity(account)
+    expires = account.get('expires_at')
+    if expires is None:
+        # 无法比较时保留既有最佳候选，仅当尚无候选时采纳
+        if identity not in best_expires:
+            best_expires[identity] = -1
+            return True
+        return False
+    prev = best_expires.get(identity, -1)
+    if expires >= prev:
+        best_expires[identity] = expires
+        return True
+    return False
+
+
+def convert_account(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    将来源账号结构转换为本项目配置结构
+
+    Args:
+        raw (Dict[str, Any]): 来自 cockpit-tools / 官方客户端的原始账号
+
+    Returns:
+        Optional[Dict[str, Any]]: 转换后的账号配置，缺少令牌时返回 None
+    """
+    access_token = raw.get('access_token')
+    if not access_token:
+        return None
+
+    account_name = raw.get('nickname') or raw.get('email') or raw.get('account_id') or '未命名账号'
+
+    # 只保留签到必需字段；region 过滤缺省即 CN，无需落盘
+    account: Dict[str, Any] = {
+        'account_name': account_name,
+        'user_id': raw.get('user_id', ''),
+        'access_token': access_token,
+    }
+    for key in ('expires_at', 'device_id'):
+        value = raw.get(key)
+        if value:
+            account[key] = value
+    return account
+
+
+def merge_into_config(new_accounts: List[Dict[str, Any]], config_path: Path) -> Dict[str, int]:
+    """
+    将账号合并写入配置文件的 trae 节点
+
+    同一 user_id 的账号更新令牌（保留自定义 account_name），新账号追加写入。
+
+    Args:
+        new_accounts (List[Dict[str, Any]]): 待导入的账号（已转换、已去重）
+        config_path (Path): 配置文件路径
+
+    Returns:
+        Dict[str, int]: 包含 added 和 updated 数量的统计字典
+    """
+    if config_path.exists():
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config_data = json.load(f)
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_data = {}
+
+    trae_node = config_data.setdefault('trae', {})
+    existing: List[Dict[str, Any]] = trae_node.setdefault('accounts', [])
+
+    index_map = {}
+    for idx, acc in enumerate(existing):
+        identity = account_identity(acc)
+        if identity:
+            index_map[identity] = idx
+
+    added = 0
+    updated = 0
+    for account in new_accounts:
+        identity = account_identity(account)
+        if identity and identity in index_map:
+            target = existing[index_map[identity]]
+            for key, value in account.items():
+                if key == 'account_name':
+                    continue
+                if key == 'source':
+                    continue
+                target[key] = value
+            updated += 1
+        else:
+            existing.append(account)
+            if identity:
+                index_map[identity] = len(existing) - 1
+            added += 1
+
+    with open(config_path, 'w', encoding='utf-8') as f:
+        json.dump(config_data, f, ensure_ascii=False, indent=2)
+
+    return {'added': added, 'updated': updated}
+
+
+def collect_accounts(quiet: bool = False) -> List[Dict[str, Any]]:
+    """
+    自动探测本机账号来源并采集 CN 账号（已按 user_id 去重、取令牌最新者）
+
+    来源顺序：cockpit-tools 数据目录 → 官方 Trae 客户端。
+    官方客户端放在最后处理：其令牌来自用户最近一次登录会话，同 user_id 时优先。
+
+    Args:
+        quiet (bool): True 时不输出来源提示
+
+    Returns:
+        List[Dict[str, Any]]: 转换后的账号配置列表，无可用来源时返回空列表
+    """
+    log = (lambda *a, **k: None) if quiet else print
+    raw_accounts: List[Dict[str, Any]] = []
+
+    for candidate in find_cockpit_data_dirs():
+        found = load_accounts_from_cockpit_dir(candidate, quiet=quiet)
+        if found:
+            log(f"📂 来源: {candidate} (发现 {len(found)} 个 CN 账号)")
+            raw_accounts.extend(found)
+
+    local = load_accounts_from_local_clients()
+    if local:
+        log(f"📂 来源: 官方 Trae 客户端 (发现 {len(local)} 个 CN 账号)")
+        raw_accounts.extend(local)
+
+    # 同身份账号保留令牌有效期最新者，其次保留来源靠后者
+    accounts: List[Dict[str, Any]] = []
+    best_expires: Dict[str, int] = {}
+    seen: Dict[str, int] = {}
+    for raw in raw_accounts:
+        converted = convert_account(raw)
+        if not converted:
+            continue
+        identity = account_identity(converted)
+        if identity:
+            if identity in seen:
+                if not _merge_best_expires(converted, best_expires):
+                    continue
+                accounts[seen[identity]] = converted
+                continue
+            seen[identity] = len(accounts)
+            _merge_best_expires(converted, best_expires)
+        accounts.append(converted)
+
+    # 账号级设备 ID 补齐：官方客户端同一目录同时有登录态 + icube-dc 设备时才可归属，
+    # 归属成功写入 account.device_id（签到请求必须携带账号自己注册的设备）。
+    device_pairs = scan_client_device_pairs()
+    if device_pairs:
+        matched = 0
+        for account in accounts:
+            user_id = str(account.get('user_id') or '')
+            if not account.get('device_id') and user_id in device_pairs:
+                account['device_id'] = device_pairs[user_id]
+                matched += 1
+        if matched:
+            log(f"📱 已按官方客户端目录配对 {matched} 个账号的签到设备 ID")
+
+    return accounts
+
+
+def sync_accounts(config_path: Optional[Path] = None, quiet: bool = False) -> Optional[Dict[str, int]]:
+    """
+    从本机 cockpit-tools / 官方客户端同步账号到配置文件（签到前的自动刷新入口）
+
+    Args:
+        config_path (Optional[Path]): 配置文件路径，默认项目根目录 config/token.json
+        quiet (bool): True 时不输出任何提示信息
+
+    Returns:
+        Optional[Dict[str, int]]: 同步统计 {'added': n, 'updated': n}；
+                                  未找到来源或无 CN 账号时返回 None
+    """
+    log = (lambda *a, **k: None) if quiet else print
+    try:
+        accounts = collect_accounts(quiet=quiet)
+        if not accounts:
+            return None
+        stats = merge_into_config(accounts, config_path or CONFIG_PATH)
+        log(f"✅ 同步完成: 新增 {stats['added']} 个，更新 {stats['updated']} 个")
+        return stats
+    except Exception as e:
+        log(f"⚠️  同步失败（不影响签到）: {e}")
+        return None
+
+
+# ============ 签到设备 ID ============
+
+
+def extract_local_icdrs_device_id() -> Optional[str]:
+    """
+    从本机 Trae CN 客户端 storage.json 提取 ICDRS 数字设备 ID
+
+    签到接口的 x-device-id 必须与客户端设备注册时一致（键名 iCubeAuthInfo://icube-dc:<did>），
+    否则服务端返回 9074 "当前参与用户太多" 拒绝领取。逻辑对齐 cockpit-tools。
+
+    Returns:
+        Optional[str]: ICDRS 设备 ID，未找到返回 None
+    """
+    for dir_name in CN_APP_DIRS:
+        for root in _appdata_roots():
+            storage_path = root / dir_name / 'User' / 'globalStorage' / 'storage.json'
+            if not storage_path.is_file():
+                continue
+            try:
+                content = storage_path.read_text(encoding='utf-8', errors='replace')
+            except OSError:
+                continue
+            marker = f'"{DEVICE_STORAGE_KEY_PREFIX}'
+            start = content.find(marker)
+            if start < 0:
+                continue
+            digits = re.match(r'\d+', content[start + len(marker):])
+            if digits:
+                return digits.group(0)
+    return None
+
+
+def get_or_create_device_id(config_dir: Optional[Path] = None) -> str:
+    """
+    获取签到用设备 ID：优先本机 Trae 客户端注册的 ICDRS 设备 ID，
+    其次读取已持久化 ID，都没有时生成一次并持久化。
+
+    Args:
+        config_dir (Optional[Path]): 设备 ID 文件所在目录，默认项目 config 目录
+
+    Returns:
+        str: 设备 ID
+    """
+    base_dir = Path(config_dir) if config_dir else project_root / "config"
+    path = base_dir / DEVICE_ID_FILE
+
+    icdrs_id = extract_local_icdrs_device_id()
+    if icdrs_id:
+        try:
+            persisted = path.read_text(encoding='utf-8').strip()
+        except OSError:
+            persisted = ''
+        if persisted != icdrs_id:
+            try:
+                base_dir.mkdir(parents=True, exist_ok=True)
+                path.write_text(icdrs_id, encoding='utf-8')
+                print(f"📱 已采用本机 Trae 客户端 ICDRS 设备 ID: {icdrs_id}")
+            except OSError:
+                pass
+        return icdrs_id
+
+    try:
+        persisted = path.read_text(encoding='utf-8').strip()
+        if persisted:
+            return persisted
+    except OSError:
+        pass
+
+    device_id = f"{int(time.time() * 1000)}_{random.randint(0, 2**32 - 1)}"
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(device_id, encoding='utf-8')
+    except OSError:
+        pass
+    return device_id
+
+
+def read_device_id(config_dir: Optional[Path] = None) -> str:
+    """仅读取已持久化的设备 ID（不主动生成），无则返回空串"""
+    base_dir = Path(config_dir) if config_dir else project_root / "config"
+    try:
+        return (base_dir / DEVICE_ID_FILE).read_text(encoding='utf-8').strip()
+    except OSError:
+        return ''
+
+
+# ============ CLI ============
+
+
+def main():
+    """主函数"""
+    parser = argparse.ArgumentParser(description='Trae CN 账号导入工具')
+    parser.add_argument('--path', help='指定 cockpit-tools 数据目录或账号 JSON 文件路径')
+    parser.add_argument('--list', action='store_true', help='仅预览待导入账号，不写入配置文件')
+    parser.add_argument('--config', help=f'指定配置文件路径，默认 {CONFIG_PATH}')
+    parser.add_argument('--device-id', action='store_true', help='仅解析并打印本机签到设备 ID')
+    args = parser.parse_args()
+
+    if args.device_id:
+        device_id = get_or_create_device_id(
+            Path(args.config).parent if args.config else None)
+        print(device_id)
+        return
+
+    config_path = Path(args.config) if args.config else CONFIG_PATH
+
+    if args.path:
+        source = Path(args.path).expanduser()
+        if not source.exists():
+            print(f"❌ 路径不存在: {source}")
+            sys.exit(1)
+
+        if source.is_dir():
+            # 目录可能是 cockpit 数据目录，也可能是 trae_accounts 目录本身
+            source_holder = source.parent if source.name == ACCOUNTS_DIR_NAME else source
+            raw_accounts = load_accounts_from_cockpit_dir(source_holder)
+        else:
+            raw_accounts = load_accounts_from_json_file(source)
+
+        print(f"📂 来源: {source}")
+        accounts = [convert_account(r) for r in raw_accounts]
+        accounts = [a for a in accounts if a]
+        accounts = _dedupe_accounts(accounts)
+    else:
+        print("🔍 正在自动探测官方 Trae 客户端与 cockpit-tools 数据目录...")
+        accounts = collect_accounts()
+
+    if not accounts:
+        print("❌ 未找到任何包含 access_token 的 CN 账号数据")
+        sys.exit(1)
+
+    print(f"\n共解析到 {len(accounts)} 个账号:")
+    for idx, account in enumerate(accounts, 1):
+        token_preview = account['access_token'][:12] + '...'
+        print(f"  {idx}. {account['account_name']} | user_id: {account.get('user_id', '-')} "
+              f"| token: {token_preview}")
+
+    if args.list:
+        print("\n👀 预览模式，未写入配置文件")
+        return
+
+    stats = merge_into_config(accounts, config_path)
+    print(f"\n✅ 导入完成: 新增 {stats['added']} 个，更新 {stats['updated']} 个")
+    print(f"📝 配置文件: {config_path}")
+
+
+def load_accounts_from_json_file(file_path: Path) -> List[Dict[str, Any]]:
+    """从单个 JSON 文件读取账号，支持单对象、数组以及 {"accounts": [...]} 结构"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"❌ 读取文件失败: {e}")
+        return []
+
+    if isinstance(data, dict):
+        if data.get('ciphertext'):
+            key_path = find_secure_key(file_path.parent)
+            if key_path:
+                try:
+                    key = base64.b64decode(key_path.read_text(encoding='utf-8').strip())
+                    dec = decrypt_record(data, key)
+                    if dec:
+                        data = dec
+                except Exception as e:
+                    print(f"⚠️  解密文件 {file_path.name} 失败: {e}")
+        if isinstance(data.get('accounts'), list):
+            data = data['accounts']
+        elif isinstance(data.get('trae'), dict) and isinstance(data['trae'].get('accounts'), list):
+            data = data['trae']['accounts']
+        else:
+            data = [data]
+
+    if not isinstance(data, list):
+        return []
+
+    result = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        # 项目配置格式可直接导入（不含 trae_auth_raw）
+        if item.get('access_token'):
+            account = {
+                'user_id': str(item.get('user_id') or item.get('id') or ''),
+                'nickname': item.get('nickname') or item.get('account_name') or item.get('email') or '',
+                'email': item.get('email') or 'unknown',
+                'access_token': item['access_token'],
+                'expires_at': item.get('expires_at'),
+            }
+            if item.get('device_id'):
+                account['device_id'] = str(item['device_id'])
+            result.append(account)
+    return result
+
+
+def _dedupe_accounts(accounts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """按 user_id 去重，保留 expires_at 最新者"""
+    result: List[Dict[str, Any]] = []
+    best_expires: Dict[str, int] = {}
+    seen: Dict[str, int] = {}
+    for account in accounts:
+        identity = account_identity(account)
+        if identity:
+            if identity in seen:
+                if not _merge_best_expires(account, best_expires):
+                    continue
+                result[seen[identity]] = account
+                continue
+            seen[identity] = len(result)
+            _merge_best_expires(account, best_expires)
+        result.append(account)
+    return result
+
+
+if __name__ == '__main__':
+    main()

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+new Env('TraeCN签到');
+cron: 30 8 * * *
+"""
+
+"""
+Trae CN 每日签到脚本
+
+Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账号领取签到积分。
+接口实现参考 cockpit-tools PR #2179 (feat/trae-cn-checkin-credits)：
+- 签到状态: POST https://api.trae.cn/trae/api/v2/ug/checkin_credits/status
+- 领取积分: POST https://api.trae.cn/trae/api/v2/ug/checkin_credits/claim
+
+设备绑定说明（重要）：
+- Trae CN 的签到按「账号 × 已注册设备」校验，x-device-id 必须使用该账号自己注册的
+  设备（本机客户端 icube-dc 键后缀的 16 位数字 ID）。
+- 一台机器上多个账号共用同一设备时，只有该设备所属账号能领取成功，其它账号会被服务端
+  以 code=9095（当前设备今日已经签到 / 设备维度限额）或 code=9074（设备未登记/冲突，
+  文案常为「当前参与用户太多」）拒绝。
+- 伪造/随机设备不可行（实测 code=9074）。
+- 因此每个账号建议单独配置其 device_id；单账号场景下脚本会自动回退使用本机主客户端设备。
+
+主要能力：
+- 多账号依次处理，账号间随机延迟 5-10 秒
+- 账号级签到设备 ID：优先取账号自身配置/官方客户端配对设备
+- 网页会话（session）失效时自动回退该账号 access_token 再试一次
+- 令牌本地过期预检（expires_at），HTTP 连接/5xx 自动重试（会话复用）
+- 领取失败自动复查状态，区分「真已签到」与「设备冲突/未登记」，如实上报
+- 汇总与推送单列「需更新凭证」账号，便于及时处理
+
+Author: Assistant
+Date: 2026-09-07
+"""
+
+import json
+import logging
+import os
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# 获取项目根目录
+project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from api import TraeAPI, TraeWebAPI
+from import_accounts import (
+    get_or_create_device_id,
+    scan_client_device_pairs,
+)
+from notification import send_notification, NotificationSound
+
+# 启动随机延迟上限（秒）：在窗口内随机错开请求，避免与他人撞车；设为 0 关闭
+JITTER_MAX_SECONDS = int(os.environ.get('TRAE_JITTER_MAX', '600'))
+
+# 领取接口设备类错误码：9074 设备未登记/冲突；9095 设备当日已用于其它账号签到
+DEVICE_CONFLICT_CODES = {9074, 9095}
+# 9074：设备未登记或伪造（文案「当前参与用户太多」）；9095：共享设备今日已被其它账号占用
+DEVICE_MISSING_HINT = (
+    "签到被设备校验拒绝（code={code}: {message}）。Trae CN 领取积分必须使用该账号"
+    "自己注册的设备（x-device-id），伪造/随机设备不可用。请先在本机官方 Trae 客户端"
+    "用该账号登录一次完成设备注册后重新导入，或在账号配置中手动填写其 device_id。"
+)
+DEVICE_SHARED_HINT = "共享设备今日已被其它账号签到（code={code}: {message}），该设备每日仅一次签到名额。如需独立签到请改用网页会话模式（配置 session 即可，无需本机设备）。"
+
+
+def web_device_for(user_id: str) -> str:
+    """
+    网页会话模式的稳定随机设备 ID（16 位数字）
+
+    实测网页链路（GetUserToken 换的 JWT）不校验客户端注册设备，随机设备即可签到；
+    按 user_id 固定生成，保证同一账号每天用同一设备、重复运行幂等。
+    """
+    seed = f'trae-web:{user_id}'
+    rng = random.Random(seed)
+    return str(rng.randint(10 ** 15, 10 ** 16 - 1))
+
+
+class TraeTasks:
+    """Trae CN 签到任务自动化执行类"""
+
+    def __init__(self, config_path: str = None):
+        """
+        初始化任务执行器
+
+        Args:
+            config_path (str): 配置文件的完整路径，如果为 None 则使用项目根目录下的 config/token.json
+        """
+        if config_path is None:
+            self.config_path = project_root / "config" / "token.json"
+        else:
+            self.config_path = Path(config_path)
+
+        self.accounts: List[Dict[str, Any]] = []
+        self.logger = self._setup_logger()
+        self._init_accounts()
+        self.account_results: List[Dict[str, Any]] = []
+
+    def _setup_logger(self) -> logging.Logger:
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        console_handler.setFormatter(formatter)
+
+        if not logger.handlers:
+            logger.addHandler(console_handler)
+
+        return logger
+
+    def _init_accounts(self):
+        """从配置文件的 trae 节点读取账号信息"""
+        if not self.config_path.exists():
+            self.logger.error(f"配置文件不存在: {self.config_path}")
+            raise FileNotFoundError(f"配置文件不存在: {self.config_path}")
+
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+            trae_config = config_data.get('trae', {})
+            self.accounts = trae_config.get('accounts', [])
+            # 只保留 CN 账号（签到积分接口仅存在于 Trae CN）
+            self.accounts = [a for a in self.accounts if a.get('region', 'CN') == 'CN']
+
+            if not self.accounts:
+                self.logger.warning("配置文件中没有找到 Trae CN 账号信息")
+            else:
+                self.logger.info(f"成功加载 {len(self.accounts)} 个 CN 账号配置")
+
+        except json.JSONDecodeError as e:
+            self.logger.error(f"配置文件JSON解析失败: {e}")
+            raise
+        except Exception as e:
+            self.logger.error(f"读取配置文件失败: {e}")
+            raise
+
+    def resolve_device_for(self, account: Dict[str, Any], pair_map: Dict[str, str],
+                           shared_device: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        """
+        解析账号的签到设备 ID（签到领取必须携带账号自己注册的设备）
+
+        优先级：账号配置 device_id → 官方客户端配对（userId 匹配）→
+        显式授权使用本机主客户端设备（use_shared_device=true 或单账号场景）→ 无。
+
+        Returns:
+            Tuple[Optional[str], Optional[str]]: (device_id, 缺失原因)，可取到设备时第二项为 None
+        """
+        device = str(account.get('device_id') or '').strip()
+        if device:
+            return device, None
+
+        user_id = str(account.get('user_id') or '')
+        if user_id and user_id in pair_map:
+            return pair_map[user_id], None
+
+        # 本机主客户端设备是「单设备每日仅一次」的共享资源：仅当账号显式授权
+        # （use_shared_device=true 或全配置仅此一个 CN 账号）时才回退使用
+        if shared_device and (bool(account.get('use_shared_device')) or len(self.accounts) == 1):
+            return shared_device, None
+
+        return None, (
+            "账号未配置签到设备 device_id，本机官方客户端无该账号的注册设备配对，"
+            "也未授权使用本机共享设备。Trae CN 桌面令牌链路领取必须用该账号自己注册"
+            "的设备（伪造/随机设备会 code=9074，多账号共用会 code=9095）。"
+            "多账号场景建议改为网页会话模式：为该账号配置 session"
+            "（浏览器 https://www.trae.cn 登录后复制 X-Cloudide-Session）即不受本机"
+            "设备限制。单账号可将 use_shared_device 置为 true 使用本机主客户端设备"
+            "（该设备每日只能成功领取一次）。"
+        )
+
+    def _build_api(self, account_info: Dict[str, Any], prefer_desktop: bool = False
+                   ) -> Tuple[Optional[Any], str, Optional[str], Optional[str]]:
+        """
+        按账号凭证构造 API 实例
+
+        Args:
+            account_info (Dict[str, Any]): 账号信息字典
+            prefer_desktop (bool): 为 True 时跳过 session，强制走桌面令牌（用于会话失效回退）
+
+        Returns:
+            Tuple[Optional[Any], str, Optional[str], Optional[str]]:
+                (api, mode, device_id, missing_reason)；api 为 None 表示凭证不可用
+        """
+        session = str(account_info.get('session') or '').strip()
+        if session and not prefer_desktop:
+            user_key = str(account_info.get('user_id') or account_info.get('account_name') or '')
+            device_id = str(account_info.get('device_id') or '').strip() or web_device_for(user_key)
+            return TraeWebAPI(session=session, device_id=device_id), '网页会话', device_id, None
+
+        access_token = account_info.get('access_token')
+        if not access_token:
+            return None, '', None, '账号配置缺少 access_token（或未配置 session）'
+
+        expires_at = account_info.get('expires_at')
+        if expires_at:
+            try:
+                if time.time() > float(expires_at):
+                    expired = time.strftime('%Y-%m-%d %H:%M', time.localtime(float(expires_at)))
+                    return None, '', None, f'access_token 已于 {expired} 过期，请重新导入账号'
+            except (TypeError, ValueError):
+                pass
+
+        device_id, missing_reason = self.resolve_device_for(
+            account_info, self.device_pair_map, self.shared_device)
+        mode = '桌面令牌（会话失效回退）' if (prefer_desktop and session) else '桌面令牌'
+        return TraeAPI(access_token=access_token, device_id=device_id or ''), mode, device_id, missing_reason
+
+    def process_account(self, account_info: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        处理单个账号的签到任务
+
+        Args:
+            account_info (Dict[str, Any]): 账号信息字典
+
+        Returns:
+            Dict[str, Any]: 处理结果
+        """
+        account_name = account_info.get('account_name') or account_info.get('email') or '未命名账号'
+        self.logger.info(f"\n{'=' * 60}")
+        self.logger.info(f"开始处理账号: {account_name}")
+        self.logger.info(f"{'=' * 60}")
+
+        result = {
+            'account_name': account_name,
+            'success': False,
+            'message': '',
+            'already_checked': False,
+            'gained': None,
+            'token_error': False,
+            'device_missing': False,
+        }
+
+        try:
+            api, mode, device_id, missing_reason = self._build_api(account_info)
+            if api is None:
+                result['message'] = missing_reason
+                result['token_error'] = True
+                self.logger.error(f"❌ {account_name}: {missing_reason}")
+                return result
+
+            # 查询签到状态（状态接口与设备无关，无设备也可查询）
+            self.logger.info(f"{account_name} - 查询签到状态（{mode}）")
+            status = api.get_checkin_status()
+
+            # 网页会话失效且账号仍有 access_token：回退桌面令牌再试一次
+            if (not status['success'] and status.get('error_type') == 'session_invalid'
+                    and account_info.get('access_token')):
+                self.logger.warning(f"⚠️ {account_name} 网页会话已失效，回退桌面令牌重试")
+                api, mode, device_id, missing_reason = self._build_api(
+                    account_info, prefer_desktop=True)
+                if api is None:
+                    result['message'] = f"{missing_reason}（网页会话已失效）"
+                    result['token_error'] = True
+                    self.logger.error(f"❌ {account_name} {result['message']}")
+                    return result
+                status = api.get_checkin_status()
+
+            if not status['success']:
+                if status.get('error_type') in ('token_expired', 'session_invalid'):
+                    result['message'] = f"{status.get('error', '凭证已失效')}，请重新导入账号/更新 session"
+                    result['token_error'] = True
+                    self.logger.error(f"❌ {account_name} {result['message']}")
+                else:
+                    result['message'] = status.get('error', '查询签到状态失败')
+                    self.logger.error(f"❌ {account_name} {result['message']}")
+                return result
+
+            # 功能不可用（服务端 enable=false，如活动未开放）
+            if not status.get('enable', True):
+                result['success'] = True
+                result['message'] = '签到活动未开启或不适用'
+                self.logger.info(f"ℹ️ {account_name} 签到活动未开启")
+                return result
+
+            # 今日已签到（状态接口为账号维度，与本次所用设备无关）
+            if status.get('checked_in'):
+                result['success'] = True
+                result['already_checked'] = True
+                result['message'] = '今日已签到'
+                self.logger.info(f"✅ {account_name} 今日已签到")
+                return result
+
+            # dry-run 模式不执行领取
+            if self.dry_run:
+                result['success'] = True
+                result['message'] = '状态正常，dry-run 未执行签到'
+                self.logger.info(f"👀 {account_name} 状态正常（dry-run 跳过领取）")
+                return result
+
+            # 桌面令牌模式且未配置设备：无法领取，如实提示（不能伪造/复用主设备）
+            if mode.startswith('桌面令牌') and not device_id:
+                result['message'] = missing_reason or '账号缺少签到设备 device_id'
+                result['device_missing'] = True
+                self.logger.warning(f"⚠️ {account_name} 缺少签到设备: {result['message']}")
+                return result
+
+            # 执行签到
+            self.logger.info(f"{account_name} - 执行签到 (device={device_id})")
+            checkin = api.claim_checkin()
+
+            if checkin['success']:
+                result['success'] = True
+                result['message'] = checkin.get('message') or '签到成功'
+                result['gained'] = checkin.get('credits')
+                extra = f"，奖励 {result['gained']} 积分" if result['gained'] is not None else ''
+                self.logger.info(f"✅ {account_name} 签到成功{extra}")
+            else:
+                # 凭证失效单独处理
+                if checkin.get('error_type') in ('token_expired', 'session_invalid'):
+                    result['message'] = f"{checkin.get('error', '凭证已失效')}，请重新导入账号/更新 session"
+                    result['token_error'] = True
+                    self.logger.error(f"❌ {account_name} {result['message']}")
+                    return result
+
+                # 领取失败后复查状态：status 为账号维度，若已变真签到则按已签处理
+                latest = api.get_checkin_status()
+                if latest['success'] and latest.get('checked_in'):
+                    result['success'] = True
+                    result['already_checked'] = True
+                    result['message'] = '领取报错但复查已签到'
+                    self.logger.info(f"✅ {account_name} 领取报错但复查已签到")
+                    return result
+
+                # 设备类错误给出可操作指引；其它错误保留服务端原文
+                code = checkin.get('code')
+                raw_error = checkin.get('error', '签到失败')
+                if code in DEVICE_CONFLICT_CODES or '设备' in raw_error or '参与用户' in raw_error:
+                    if code == 9095:
+                        result['message'] = DEVICE_SHARED_HINT.format(code=code or '?', message=raw_error)
+                    else:
+                        result['message'] = DEVICE_MISSING_HINT.format(code=code or '?', message=raw_error)
+                    result['device_missing'] = True
+                else:
+                    result['message'] = raw_error
+                self.logger.error(f"❌ {account_name} 签到失败: {result['message']}")
+
+        except Exception as e:
+            error_msg = f"处理账号时发生异常: {str(e)}"
+            self.logger.error(f"❌ {error_msg}")
+            import traceback
+            traceback.print_exc()
+            result['message'] = error_msg
+
+        return result
+
+    def run(self, dry_run: bool = False):
+        """执行所有账号的签到任务"""
+        self.dry_run = dry_run
+
+        # 设备解析：官方客户端 userId→设备配对表；本机主客户端设备仅在单账号或
+        # 账号显式 use_shared_device=true 时回退使用
+        self.device_pair_map = scan_client_device_pairs()
+        if self.device_pair_map:
+            self.logger.info(f"📱 官方客户端设备配对: {len(self.device_pair_map)} 个")
+        use_shared = len(self.accounts) == 1 or any(
+            a.get('use_shared_device') for a in self.accounts)
+        self.shared_device = get_or_create_device_id(self.config_path.parent) if use_shared else None
+        if self.shared_device:
+            scope = '单账号' if len(self.accounts) == 1 else '显式授权'
+            self.logger.info(f"📱 {scope}场景回退本机主客户端设备: {self.shared_device}")
+
+        # 启动随机抖动，错开请求高峰
+        if JITTER_MAX_SECONDS > 0:
+            delay = random.uniform(0, JITTER_MAX_SECONDS)
+            self.logger.info(f"⏱️  随机延迟 {delay:.0f} 秒后开始（可通过环境变量 TRAE_JITTER_MAX 调整）")
+            time.sleep(delay)
+
+        self.logger.info("=" * 60)
+        self.logger.info("Trae CN 自动签到任务开始" + ("（dry-run 状态检查）" if dry_run else ""))
+        self.logger.info("=" * 60)
+
+        if not self.accounts:
+            self.logger.warning("没有需要处理的账号")
+            return
+
+        for idx, account_info in enumerate(self.accounts):
+            result = self.process_account(account_info)
+            self.account_results.append(result)
+
+            # 处理完一个账号后，如果还有下一个账号，则等待 5-10 秒
+            if idx < len(self.accounts) - 1:
+                delay = random.uniform(5, 10)
+                self.logger.info(f"\n⏱️  等待 {delay:.1f} 秒后处理下一个账号...")
+                time.sleep(delay)
+
+        self._print_summary()
+        if not dry_run:
+            self._send_notification()
+
+    def _print_summary(self):
+        """打印执行结果统计"""
+        self.logger.info("\n" + "=" * 60)
+        self.logger.info("执行结果统计")
+        self.logger.info("=" * 60)
+
+        total = len(self.account_results)
+        success = sum(1 for r in self.account_results if r['success'])
+        already = sum(1 for r in self.account_results if r.get('already_checked'))
+        failed = total - success
+        token_failed = sum(1 for r in self.account_results if r.get('token_error'))
+        device_missing = sum(1 for r in self.account_results if r.get('device_missing'))
+
+        self.logger.info(f"总账号数: {total}")
+        self.logger.info(f"签到成功: {success - already}")
+        self.logger.info(f"今日已签: {already}")
+        self.logger.info(f"签到失败: {failed}")
+        if token_failed:
+            self.logger.info(f"其中需更新凭证: {token_failed}")
+            for r in self.account_results:
+                if r.get('token_error'):
+                    self.logger.info(f"  ⚠️ {r['account_name']} 凭证失效，需重新导入账号/更新 session")
+        if device_missing:
+            self.logger.info(f"其中设备缺失/冲突: {device_missing}")
+
+        self.logger.info("\n详细结果:")
+        for result in self.account_results:
+            status = "✅ 成功" if result['success'] else "❌ 失败"
+            self.logger.info(f"  {result['account_name']}: {status} - {result['message']}")
+
+        self.logger.info("=" * 60)
+
+    def _send_notification(self):
+        """发送推送通知"""
+        if not self.account_results:
+            return
+
+        total = len(self.account_results)
+        success = sum(1 for r in self.account_results if r['success'])
+        already = sum(1 for r in self.account_results if r.get('already_checked'))
+        failed = total - success
+        token_failed = sum(1 for r in self.account_results if r.get('token_error'))
+
+        title = "Trae CN签到结果通知"
+
+        content_lines = [
+            f"📊 总账号数: {total}",
+            f"✅ 签到成功: {success - already}",
+            f"📅 今日已签: {already}",
+            f"❌ 签到失败: {failed}",
+        ]
+        if token_failed:
+            content_lines.append(f"⚠️ 需更新凭证: {token_failed}")
+        content_lines += ["", "📋 详细结果:"]
+
+        for result in self.account_results:
+            status = "✅" if result['success'] else "❌"
+            content_lines.append(f"{status} {result['account_name']}: {result['message']}")
+            if result.get('gained') is not None:
+                content_lines.append(f"    🎁 奖励积分: {result['gained']}")
+
+        content = "\n".join(content_lines)
+
+        try:
+            send_notification(
+                title=title,
+                content=content,
+                sound=NotificationSound.BIRDSONG
+            )
+            self.logger.info("✅ 推送通知已发送")
+        except Exception as e:
+            self.logger.warning(f"⚠️ 发送推送通知失败: {str(e)}")
+
+
+def main():
+    """主函数"""
+    dry_run = '--dry-run' in sys.argv
+    try:
+        tasks = TraeTasks()
+        tasks.run(dry_run=dry_run)
+
+    except FileNotFoundError as e:
+        print(f"❌ 错误: {e}")
+        print("请确保配置文件存在并包含 trae 账号信息")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ 发生未知错误: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -68,18 +68,6 @@ DEVICE_MISSING_HINT = (
 DEVICE_SHARED_HINT = "共享设备今日已被其它账号签到（code={code}: {message}），该设备每日仅一次签到名额。如需独立签到请改用网页会话模式（配置 session 即可，无需本机设备）。"
 
 
-def web_device_for(user_id: str) -> str:
-    """
-    网页会话模式的稳定随机设备 ID（16 位数字）
-
-    实测网页链路（GetUserToken 换的 JWT）不校验客户端注册设备，随机设备即可签到；
-    按 user_id 固定生成，保证同一账号每天用同一设备、重复运行幂等。
-    """
-    seed = f'trae-web:{user_id}'
-    rng = random.Random(seed)
-    return str(rng.randint(10 ** 15, 10 ** 16 - 1))
-
-
 class TraeTasks:
     """Trae CN 签到任务自动化执行类"""
 
@@ -193,8 +181,9 @@ class TraeTasks:
         """
         session = str(account_info.get('session') or '').strip()
         if session and not prefer_desktop:
-            user_key = str(account_info.get('user_id') or account_info.get('account_name') or '')
-            device_id = str(account_info.get('device_id') or '').strip() or web_device_for(user_key)
+            # 网页会话 JWT 不绑定设备，随机设备即可签到；实测固定设备会触发
+            # code=9095（该设备当日已被占用），故每次运行使用全新随机设备
+            device_id = str(random.randint(10 ** 15, 10 ** 16 - 1))
             return TraeWebAPI(session=session, device_id=device_id), '网页会话', device_id, None
 
         access_token = account_info.get('access_token')

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -20,6 +20,8 @@ Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账
   或 code=9074（设备未登记/冲突，文案常为「当前参与用户太多」）拒绝。
 - 网页会话模式（session，推荐多账号）：用 X-Cloudide-Session 换取 JWT 后，随机 16 位设备
   即可签到（实测 code=0）。9074 为偶发风控，脚本会自动换随机设备重试 2 次。
+- 长效登录 Cookie（refresh_cookies，可选）：配置后每次运行先调 /cloudide/api/v3/trae/Login
+  自动刷新 X-Cloudide-Session（与浏览器打开 trae.cn 的续期链路一致），session 约 60 天不失效。
 
 主要能力：
 - 多账号依次处理，账号间随机延迟 5-10 秒
@@ -27,6 +29,7 @@ Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账
 - 网页会话（session）失效时自动回退该账号 access_token 再试一次
 - 令牌本地过期预检（expires_at），HTTP 连接/5xx 自动重试（会话复用）
 - 网页会话 9074 偶发风控自动换设备重试；领取失败自动复查状态，如实上报
+- 长效 Cookie 自动刷新 session，隔天/隔周签到不因 session 过期失效
 - 汇总与推送单列「需更新凭证」账号，便于及时处理
 
 Author: Assistant
@@ -47,7 +50,7 @@ project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from api import TraeAPI, TraeWebAPI
+from api import TraeAPI, TraeWebAPI, login_refresh
 from import_accounts import (
     get_or_create_device_id,
     scan_client_device_pairs,
@@ -180,6 +183,20 @@ class TraeTasks:
                 (api, mode, device_id, missing_reason)；api 为 None 表示凭证不可用
         """
         session = str(account_info.get('session') or '').strip()
+        refresh_cookies = str(account_info.get('refresh_cookies') or '').strip()
+        if refresh_cookies:
+            # 配置了长效登录 Cookie 时，每次运行先调 /cloudide/api/v3/trae/Login
+            # 刷新 X-Cloudide-Session，保证隔天/隔周 session 失效也能自动续期
+            refreshed = login_refresh(refresh_cookies)
+            if refreshed['success']:
+                session = refreshed['session']
+                account_info['session'] = session
+                self.logger.info(
+                    f"{account_info.get('account_name') or '账号'} - 已用长效 Cookie 刷新 session")
+            else:
+                self.logger.warning(
+                    f"{account_info.get('account_name') or '账号'} 刷新登录态失败: "
+                    f"{refreshed['error']}，改用旧 session")
         if session and not prefer_desktop:
             # 网页会话 JWT 不绑定设备，随机设备即可签到；实测固定设备会触发
             # code=9095（该设备当日已被占用），故每次运行使用全新随机设备

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -13,21 +13,20 @@ Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账
 - 签到状态: POST https://api.trae.cn/trae/api/v2/ug/checkin_credits/status
 - 领取积分: POST https://api.trae.cn/trae/api/v2/ug/checkin_credits/claim
 
-设备绑定说明（重要）：
-- Trae CN 的签到按「账号 × 已注册设备」校验，x-device-id 必须使用该账号自己注册的
-  设备（本机客户端 icube-dc 键后缀的 16 位数字 ID）。
-- 一台机器上多个账号共用同一设备时，只有该设备所属账号能领取成功，其它账号会被服务端
-  以 code=9095（当前设备今日已经签到 / 设备维度限额）或 code=9074（设备未登记/冲突，
-  文案常为「当前参与用户太多」）拒绝。
-- 伪造/随机设备不可行（实测 code=9074）。
-- 因此每个账号建议单独配置其 device_id；单账号场景下脚本会自动回退使用本机主客户端设备。
+设备绑定说明（重要，按凭证模式区分）：
+- 桌面令牌模式（access_token）：签到按「账号 × 已注册设备」校验，x-device-id 必须使用该账号
+  自己注册的设备（本机客户端 icube-dc 键后缀的 16 位数字 ID）。一台机器上多个账号共用同一
+  设备时，只有该设备所属账号能领取成功，其它账号会被服务端以 code=9095（设备当日已被占用）
+  或 code=9074（设备未登记/冲突，文案常为「当前参与用户太多」）拒绝。
+- 网页会话模式（session，推荐多账号）：用 X-Cloudide-Session 换取 JWT 后，随机 16 位设备
+  即可签到（实测 code=0）。9074 为偶发风控，脚本会自动换随机设备重试 2 次。
 
 主要能力：
 - 多账号依次处理，账号间随机延迟 5-10 秒
 - 账号级签到设备 ID：优先取账号自身配置/官方客户端配对设备
 - 网页会话（session）失效时自动回退该账号 access_token 再试一次
 - 令牌本地过期预检（expires_at），HTTP 连接/5xx 自动重试（会话复用）
-- 领取失败自动复查状态，区分「真已签到」与「设备冲突/未登记」，如实上报
+- 网页会话 9074 偶发风控自动换设备重试；领取失败自动复查状态，如实上报
 - 汇总与推送单列「需更新凭证」账号，便于及时处理
 
 Author: Assistant
@@ -309,6 +308,21 @@ class TraeTasks:
             self.logger.info(f"{account_name} - 执行签到 (device={device_id})")
             checkin = api.claim_checkin()
 
+            # 网页会话模式：9074 为偶发风控（实测随机设备可签到，见 web_checkin.py 验证），
+            # 换全新随机设备重试 2 次；桌面令牌模式 9074 是真实设备错误，不重试
+            if (not checkin['success'] and checkin.get('code') == 9074
+                    and mode == '网页会话'):
+                for attempt in range(2):
+                    retry_device = str(random.randint(10 ** 15, 10 ** 16 - 1))
+                    self.logger.info(
+                        f"🔄 {account_name} 9074 偶发风控，换随机设备重试 ({attempt + 1}/2)")
+                    retry_api = TraeWebAPI(
+                        session=str(account_info.get('session') or ''),
+                        device_id=retry_device)
+                    checkin = retry_api.claim_checkin()
+                    if checkin['success']:
+                        break
+
             if checkin['success']:
                 result['success'] = True
                 result['message'] = checkin.get('message') or '签到成功'
@@ -338,9 +352,14 @@ class TraeTasks:
                 if code in DEVICE_CONFLICT_CODES or '设备' in raw_error or '参与用户' in raw_error:
                     if code == 9095:
                         result['message'] = DEVICE_SHARED_HINT.format(code=code or '?', message=raw_error)
+                    elif mode == '网页会话':
+                        result['message'] = (
+                            f"签到被临时风控拒绝（code={code}: {raw_error}），已自动换随机设备重试仍失败。"
+                            "网页会话模式无需绑定设备，稍后重跑即可；若持续失败请确认 session 仍有效。"
+                        )
                     else:
                         result['message'] = DEVICE_MISSING_HINT.format(code=code or '?', message=raw_error)
-                    result['device_missing'] = True
+                        result['device_missing'] = True
                 else:
                     result['message'] = raw_error
                 self.logger.error(f"❌ {account_name} 签到失败: {result['message']}")

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -20,7 +20,7 @@ Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账
   或 code=9074（设备未登记/冲突，文案常为「当前参与用户太多」）拒绝。
 - 网页会话模式（session，推荐多账号）：用 X-Cloudide-Session 换取 JWT 后，随机 16 位设备
   即可签到（实测 code=0）。9074 为偶发风控，脚本会自动换随机设备重试 2 次。
-- 长效登录 Cookie（refresh_cookies，推荐）：配置后每次运行先调 /cloudide/api/v3/trae/Login
+- 长效登录 Cookie（sessionid，推荐）：配置后每次运行先调 /cloudide/api/v3/trae/Login
   自动刷新 X-Cloudide-Session（与浏览器打开 trae.cn 的续期链路一致）。实测只需
   `sessionid` 一个 Cookie 即可刷新，约 60 天不失效；配了它就不再需要手工更新 session。
 
@@ -184,11 +184,11 @@ class TraeTasks:
                 (api, mode, device_id, missing_reason)；api 为 None 表示凭证不可用
         """
         session = str(account_info.get('session') or '').strip()
-        refresh_cookies = str(account_info.get('refresh_cookies') or '').strip()
-        if refresh_cookies:
+        sessionid = str(account_info.get('sessionid') or '').strip()
+        if sessionid:
             # 配置了长效登录 Cookie 时，每次运行先调 /cloudide/api/v3/trae/Login
             # 刷新 X-Cloudide-Session，保证隔天/隔周 session 失效也能自动续期
-            refreshed = login_refresh(refresh_cookies)
+            refreshed = login_refresh(sessionid)
             if refreshed['success']:
                 session = refreshed['session']
                 account_info['session'] = session
@@ -206,8 +206,8 @@ class TraeTasks:
 
         access_token = account_info.get('access_token')
         if not access_token:
-            if refresh_cookies:
-                return None, '', None, 'refresh_cookies 失效且未配置 session/access_token，请回浏览器重新复制 sessionid'
+            if sessionid:
+                return None, '', None, 'sessionid 失效且未配置 session/access_token，请回浏览器重新复制 sessionid'
             return None, '', None, '账号配置缺少 access_token（或未配置 session）'
 
         expires_at = account_info.get('expires_at')

--- a/script/trae/main.py
+++ b/script/trae/main.py
@@ -20,8 +20,9 @@ Trae CN 已切换为积分计费，本脚本每天自动为配置中的每个账
   或 code=9074（设备未登记/冲突，文案常为「当前参与用户太多」）拒绝。
 - 网页会话模式（session，推荐多账号）：用 X-Cloudide-Session 换取 JWT 后，随机 16 位设备
   即可签到（实测 code=0）。9074 为偶发风控，脚本会自动换随机设备重试 2 次。
-- 长效登录 Cookie（refresh_cookies，可选）：配置后每次运行先调 /cloudide/api/v3/trae/Login
-  自动刷新 X-Cloudide-Session（与浏览器打开 trae.cn 的续期链路一致），session 约 60 天不失效。
+- 长效登录 Cookie（refresh_cookies，推荐）：配置后每次运行先调 /cloudide/api/v3/trae/Login
+  自动刷新 X-Cloudide-Session（与浏览器打开 trae.cn 的续期链路一致）。实测只需
+  `sessionid` 一个 Cookie 即可刷新，约 60 天不失效；配了它就不再需要手工更新 session。
 
 主要能力：
 - 多账号依次处理，账号间随机延迟 5-10 秒
@@ -205,6 +206,8 @@ class TraeTasks:
 
         access_token = account_info.get('access_token')
         if not access_token:
+            if refresh_cookies:
+                return None, '', None, 'refresh_cookies 失效且未配置 session/access_token，请回浏览器重新复制 sessionid'
             return None, '', None, '账号配置缺少 access_token（或未配置 session）'
 
         expires_at = account_info.get('expires_at')

--- a/script/trae/web_checkin.py
+++ b/script/trae/web_checkin.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Trae CN 网页会话签到验证工具（方案 C：验证 star620 的云端思路）
+
+思路（参考 star620/TRAE-Automatic-sign-in 的云端脚本）：
+- 网页端登录态的 HttpOnly Cookie `X-Cloudide-Session`（约 14 天有效）
+- 用它 POST /cloudide/api/v3/common/GetUserToken 换取全新 JWT（Cloud-IDE-JWT）
+- 换来的 JWT + 「该账号独立随机 16 位设备」去执行每日签到
+
+目的：验证「不依赖本机客户端注册设备、每账号用随机设备」能否在 api.trae.cn 签到。
+若 code=0 成立，说明网页会话签到的设备校验与桌面链路不同，多账号可绕开一机一设备限制；
+若仍 9074/9095，则说明服务端对设备校验与令牌来源无关，此路不通。
+
+用法：
+    python web_checkin.py --session "X-Cloudide-Session 的 Cookie 值"
+    # 或环境变量：TRAE_SESSION=...
+
+Cookie 获取（浏览器一次即可）：
+1. 浏览器打开 https://www.trae.cn 并登录目标账号（手机验证码/扫码）
+2. F12 → 应用(Application) → Cookie → https://www.trae.cn
+3. 找到 `X-Cloudide-Session`，复制其 Value（可能很长，含 %2F 等无需转义）
+"""
+
+import json
+import os
+import random
+import sys
+import urllib.request
+
+BASE = "https://api.trae.cn"
+
+
+def post(path: str, headers: dict, body: str = "") -> tuple:
+    req = urllib.request.Request(BASE + path, data=body.encode("utf-8"),
+                                 headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")
+
+
+def get_token(session: str) -> str:
+    """用 X-Cloudide-Session Cookie 换取全新 JWT"""
+    headers = {
+        "Cookie": "X-Cloudide-Session=" + session,
+        "Referer": "https://www.trae.cn/",
+        "Origin": "https://www.trae.cn",
+        "User-Agent": "TraeCheckin/1.0",
+        "Accept": "application/json, text/plain, */*",
+    }
+    status, text = post("/cloudide/api/v3/common/GetUserToken", headers)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        print("GetUserToken 返回非 JSON: HTTP %s %s" % (status, text[:300]))
+        raise SystemExit(1)
+    token = (data.get("Result") or {}).get("Token")
+    if status != 200 or not token:
+        raise RuntimeError("GetUserToken 失败: HTTP %s %s" % (status, text[:300]))
+    return token
+
+
+def call_api(path: str, token: str, device_id: str) -> dict:
+    headers = {
+        "Authorization": "Cloud-IDE-JWT " + token,
+        "X-User-Region": "cn",
+        "x-device-id": device_id,
+        "Content-Type": "application/json",
+        "User-Agent": "TraeCheckin/1.0",
+    }
+    status, text = post(path, headers, "{}")
+    try:
+        return {"http": status, "body": json.loads(text)}
+    except json.JSONDecodeError:
+        return {"http": status, "body": {"raw": text[:300]}}
+
+
+def main() -> int:
+    session = (os.environ.get("TRAE_SESSION") or "").strip()
+    if "--session" in sys.argv:
+        idx = sys.argv.index("--session")
+        if idx + 1 < len(sys.argv):
+            session = sys.argv[idx + 1].strip()
+    if not session:
+        print("缺少 X-Cloudide-Session Cookie（--session 或环境变量 TRAE_SESSION）")
+        return 1
+    # 每次运行随机一个 16 位设备（复刻 star620 云端默认行为，用于验证）
+    device = str(random.randint(10 ** 15, 10 ** 16 - 1))
+
+    print("[1/3] 用 X-Cloudide-Session 换取 JWT ...")
+    token = get_token(session)
+    print("      成功，JWT 长度 =", len(token))
+
+    print("[2/3] 查询签到状态 (device=%s) ..." % device)
+    st = call_api("/trae/api/v2/ug/checkin_credits/status", token, device)
+    sb = st["body"]
+    print("      HTTP", st["http"], "| code", sb.get("code"),
+          "| checked", sb.get("checked_in"), "| msg", str(sb.get("message"))[:60])
+
+    print("[3/3] 领取签到 (随机设备) ...")
+    cl = call_api("/trae/api/v2/ug/checkin_credits/claim", token, device)
+    cb = cl["body"]
+    print("      HTTP", cl["http"], "| code", cb.get("code"),
+          "| credits", cb.get("credits"), "| msg", str(cb.get("message"))[:80])
+    ok = cl["http"] == 200 and (cb.get("code") in (0, 200) or cb.get("checked_in"))
+    print("")
+    print("✅ 网页会话 + 随机设备签到可行" if ok else
+          "❌ 网页会话 + 随机设备仍被拒（设备校验与令牌来源无关，此路不通）")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/trae/web_checkin.py
+++ b/script/trae/web_checkin.py
@@ -31,10 +31,8 @@ import urllib.request
 BASE = "https://api.trae.cn"
 
 
-# 与官方网页端请求一致的浏览器 UA
-DEFAULT_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-              "AppleWebKit/537.36 (KHTML, like Gecko) "
-              "Chrome/152.0.0.0 Safari/537.36")
+# 官方桌面客户端（TRAE SOLO CN）真实 UA，抓包确认；实测全链路可用
+DEFAULT_UA = "VSCode 1.107.1 (TRAE SOLO CN)"
 
 
 def post(path: str, headers: dict, body: str = "") -> tuple:

--- a/script/trae/web_checkin.py
+++ b/script/trae/web_checkin.py
@@ -31,7 +31,10 @@ import urllib.request
 BASE = "https://api.trae.cn"
 
 
-DEFAULT_UA = "Trae/1.0.0 antigravity-cockpit-tools"
+# 与官方网页端请求一致的浏览器 UA
+DEFAULT_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+              "AppleWebKit/537.36 (KHTML, like Gecko) "
+              "Chrome/152.0.0.0 Safari/537.36")
 
 
 def post(path: str, headers: dict, body: str = "") -> tuple:

--- a/script/trae/web_checkin.py
+++ b/script/trae/web_checkin.py
@@ -31,6 +31,9 @@ import urllib.request
 BASE = "https://api.trae.cn"
 
 
+DEFAULT_UA = "Trae/1.0.0 antigravity-cockpit-tools"
+
+
 def post(path: str, headers: dict, body: str = "") -> tuple:
     req = urllib.request.Request(BASE + path, data=body.encode("utf-8"),
                                  headers=headers, method="POST")
@@ -47,7 +50,7 @@ def get_token(session: str) -> str:
         "Cookie": "X-Cloudide-Session=" + session,
         "Referer": "https://www.trae.cn/",
         "Origin": "https://www.trae.cn",
-        "User-Agent": "TraeCheckin/1.0",
+        "User-Agent": DEFAULT_UA,
         "Accept": "application/json, text/plain, */*",
     }
     status, text = post("/cloudide/api/v3/common/GetUserToken", headers)
@@ -68,7 +71,7 @@ def call_api(path: str, token: str, device_id: str) -> dict:
         "X-User-Region": "cn",
         "x-device-id": device_id,
         "Content-Type": "application/json",
-        "User-Agent": "TraeCheckin/1.0",
+        "User-Agent": DEFAULT_UA,
     }
     status, text = post(path, headers, "{}")
     try:

--- a/script/trae/web_checkin.py
+++ b/script/trae/web_checkin.py
@@ -102,6 +102,15 @@ def main() -> int:
     print("[3/3] 领取签到 (随机设备) ...")
     cl = call_api("/trae/api/v2/ug/checkin_credits/claim", token, device)
     cb = cl["body"]
+    # 9074 为偶发风控（实测随机设备可签到），换设备重试 2 次避免误判
+    if cl["http"] == 200 and cb.get("code") == 9074:
+        for attempt in range(2):
+            device = str(random.randint(10 ** 15, 10 ** 16 - 1))
+            print(f"      9074 偶发风控，换随机设备重试 ({attempt + 1}/2) ...")
+            cl = call_api("/trae/api/v2/ug/checkin_credits/claim", token, device)
+            cb = cl["body"]
+            if cb.get("code") in (0, 200):
+                break
     print("      HTTP", cl["http"], "| code", cb.get("code"),
           "| credits", cb.get("credits"), "| msg", str(cb.get("message"))[:80])
     ok = cl["http"] == 200 and (cb.get("code") in (0, 200) or cb.get("checked_in"))

--- a/script/workbuddy/README.md
+++ b/script/workbuddy/README.md
@@ -8,7 +8,6 @@ WorkBuddy（腾讯 CodeBuddy）每日签到脚本，支持多账号、令牌自�
 
 - 🔐 **多账号支持** - 依次处理配置中的所有账号，账号间随机延迟 5-10 秒
 - 📥 **账号导入** - 一键导入官方 WorkBuddy 客户端当前登录账号，无需手动抓包；也支持从 cockpit-tools 批量导入
-- 🔄 **自动同步** - 每次签到前自动从本机官方客户端 / cockpit-tools 拉取最新令牌
 - 🔁 **令牌自动续期** - `access_token` 过期时用 `refresh_token` 自动换新并写回配置
 - 🎯 **智能判重** - 先查签到状态，今日已签到则跳过，不重复请求
 - ⏱️ **随机错峰** - 启动后在时间窗口内随机延迟，避开请求高峰
@@ -38,7 +37,6 @@ pip install requests pycryptodome
     "accounts": [
       {
         "account_name": "主号",
-        "email": "you@example.com",
         "access_token": "你的访问令牌",
         "refresh_token": "你的刷新令牌",
         "uid": "你的用户ID",
@@ -55,7 +53,6 @@ pip install requests pycryptodome
 | 字段 | 必填 | 说明 |
 |------|------|------|
 | `account_name` | 否 | 账号备注名，用于日志和推送显示 |
-| `email` | 否 | 账号邮箱，用于导入时去重 |
 | `access_token` | **是** | 访问令牌，对应请求头 `Authorization: Bearer` |
 | `refresh_token` | 否 | 刷新令牌，缺失时令牌过期只能手动重新导入 |
 | `uid` | 否 | 用户 ID，对应请求头 `X-User-Id` |
@@ -125,7 +122,7 @@ python import_accounts.py --path "D:/backup/my_accounts.json"
 
 ### 与 cockpit-tools 并行使用
 
-[cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的自动签到会在执行时刷新令牌（refresh token 轮换），这会使 `config/token.json` 里的旧令牌立即失效。脚本已内置应对：**每次签到前自动从本机官方客户端 / cockpit-tools 同步最新令牌**（两者都没有时自动跳过，不影响独立使用）。若两边的自动签到都已开启，建议二选一，避免重复签到。
+[cockpit-tools](https://github.com/jlcodes99/cockpit-tools) 的自动签到会在执行时刷新令牌（refresh token 轮换），这会使 `config/token.json` 里的旧令牌立即失效。脚本**不会自动从本机拉取令牌**，若两边同时使用，cockpit 侧刷新令牌后需重新运行 `import_accounts.py` 更新，或建议二选一，避免重复签到。
 
 ## 🚀 使用方法
 
@@ -136,8 +133,6 @@ python main.py
 执行流程：
 
 ```
-从本机 cockpit-tools 同步最新令牌（未安装则跳过）
-  ↓
 随机延迟 0~10 分钟（错峰，可用 WORKBUDDY_JITTER_MAX 环境变量调整）
   ↓
 加载账号配置

--- a/script/workbuddy/import_accounts.py
+++ b/script/workbuddy/import_accounts.py
@@ -537,7 +537,6 @@ def convert_account(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
     account: Dict[str, Any] = {
         'account_name': account_name,
-        'email': raw.get('email', ''),
         'access_token': access_token,
     }
 
@@ -617,7 +616,9 @@ def collect_accounts(quiet: bool = False) -> List[Dict[str, Any]]:
     """
     自动探测本机账号来源并采集账号（已转换、去重）
 
-    来源优先级：官方 WorkBuddy 客户端（当前登录账号）→ cockpit-tools 数据目录（全部账号）
+    来源顺序：cockpit-tools 数据目录（全部账号）→ 官方 WorkBuddy 客户端（当前登录账号）。
+    官方客户端放在最后处理：其令牌来自用户最近一次登录会话（服务端单会话策略下
+    旧的 refresh 链已作废），同 uid 时后处理的官方令牌会覆盖 cockpit 侧的失效令牌。
 
     Args:
         quiet (bool): True 时不输出来源提示
@@ -628,16 +629,16 @@ def collect_accounts(quiet: bool = False) -> List[Dict[str, Any]]:
     log = (lambda *a, **k: None) if quiet else print
     raw_accounts: List[Dict[str, Any]] = []
 
-    official = load_accounts_from_official_client(quiet=quiet)
-    if official:
-        log("📂 来源: 官方 WorkBuddy 客户端 (发现 1 个账号)")
-        raw_accounts.extend(official)
-
     for candidate in find_cockpit_data_dirs():
         found = load_accounts_from_dir(candidate, quiet=quiet)
         if found:
             log(f"📂 来源: {candidate} (发现 {len(found)} 个账号)")
             raw_accounts.extend(found)
+
+    official = load_accounts_from_official_client(quiet=quiet)
+    if official:
+        log("📂 来源: 官方 WorkBuddy 客户端 (发现 1 个账号)")
+        raw_accounts.extend(official)
 
     accounts: List[Dict[str, Any]] = []
     seen = set()
@@ -653,34 +654,6 @@ def collect_accounts(quiet: bool = False) -> List[Dict[str, Any]]:
         accounts.append(converted)
 
     return accounts
-
-
-def sync_accounts(config_path: Optional[Path] = None, quiet: bool = False) -> Optional[Dict[str, int]]:
-    """
-    从本机 cockpit-tools 同步账号到配置文件（签到前的自动刷新入口）
-
-    自动探测数据目录、读取并解密账号、去重后合并写入配置。
-    任何异常都不抛出，保证不影响签到主流程。
-
-    Args:
-        config_path (Optional[Path]): 配置文件路径，默认项目根目录 config/token.json
-        quiet (bool): True 时不输出任何提示信息
-
-    Returns:
-        Optional[Dict[str, int]]: 同步统计 {'added': n, 'updated': n}；
-                                  未找到 cockpit-tools 或无账号时返回 None
-    """
-    log = (lambda *a, **k: None) if quiet else print
-    try:
-        accounts = collect_accounts(quiet=quiet)
-        if not accounts:
-            return None
-        stats = merge_into_config(accounts, config_path or CONFIG_PATH)
-        log(f"✅ 同步完成: 新增 {stats['added']} 个，更新 {stats['updated']} 个")
-        return stats
-    except Exception as e:
-        log(f"⚠️  同步失败（不影响签到）: {e}")
-        return None
 
 
 def main():

--- a/script/workbuddy/main.py
+++ b/script/workbuddy/main.py
@@ -34,7 +34,6 @@ sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from api import WorkBuddyAPI
-from import_accounts import sync_accounts
 from notification import send_notification, NotificationSound
 
 # 启动随机延迟上限（秒）：在窗口内随机错开请求，避免与他人撞车；设为 0 关闭
@@ -268,14 +267,6 @@ class WorkBuddyTasks:
 
     def run(self):
         """执行所有账号的签到任务"""
-        # 签到前先从本机 cockpit-tools 同步最新令牌（未安装则跳过），避免双端令牌轮换导致 401
-        sync_stats = sync_accounts(quiet=True)
-        if sync_stats:
-            self.logger.info(
-                f"🔄 已从 cockpit-tools 同步账号: 新增 {sync_stats['added']}，更新 {sync_stats['updated']}"
-            )
-            self._init_accounts()
-
         # 启动随机抖动，错开请求高峰
         if JITTER_MAX_SECONDS > 0:
             delay = random.uniform(0, JITTER_MAX_SECONDS)


### PR DESCRIPTION
## 变更内容

- ✨ **新增 Trae CN 自动签到模块**：网页会话模式（配置 Cookie `X-Cloudide-Session`，多账号互不影响，设备 ID 自动派生）+ 桌面令牌模式（保留官方客户端导入）。
- ✨ **新增 Agent Router 每日签到模块**：重走 GitHub OAuth 登录即签到，支持余额查询、证书自动合并。
- 🔧 **优化 WorkBuddy**：移除签到前自动同步逻辑（改为需手动 `import_accounts.py` 更新），官方客户端令牌优先，精简账号配置字段。
- 📝 精简配置模板与主 README 更新日志（详细说明均在各脚本子目录 README）。

## 测试情况

> **⚠️ 本 PR 内容大部分由 AI 辅助生成，未经逐行人工 review，但功能已实测正常：**
> - Trae CN：`--dry-run` 与实跑签到正常，多账号状态查询正确
> - WorkBuddy：`import_accounts.py --list` 可正常探测/预览本机账号
> - Agent Router：脚本可正常启动并完成签到流程
>
> 提交历史已按模块整理为 4 次提交（trae / agentrouter / workbuddy / docs）。